### PR TITLE
update go-sqlbuilder Set method

### DIFF
--- a/update.go
+++ b/update.go
@@ -39,7 +39,10 @@ func (ub *UpdateBuilder) Update(table string) *UpdateBuilder {
 
 // Set sets the assignements in SET.
 func (ub *UpdateBuilder) Set(assignment ...string) *UpdateBuilder {
-	ub.assignments = assignment
+	for _, ass := range assignment {
+		ub.assignments = append(ub.assignments, ass)
+	}
+	//ub.assignments = assignment
 	return ub
 }
 


### PR DESCRIPTION
allow multiple use of the Set method，does't cover old assignment.