### PR TITLE
Modify builder

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -61,8 +61,11 @@ func (db *DeleteBuilder) Build() (sql string, args []interface{}) {
 // They can be used in `DB#Query` of package `database/sql` directly.
 func (db *DeleteBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{}) (sql string, args []interface{}) {
 	buf := &bytes.Buffer{}
-	buf.WriteString("DELETE FROM ")
-	buf.WriteString(db.table)
+
+	if db.table != "" {
+		buf.WriteString("DELETE FROM ")
+		buf.WriteString(db.table)
+	}
 
 	if len(db.whereExprs) > 0 {
 		buf.WriteString(" WHERE ")

--- a/insert.go
+++ b/insert.go
@@ -87,9 +87,12 @@ func (ib *InsertBuilder) Build() (sql string, args []interface{}) {
 // They can be used in `DB#Query` of package `database/sql` directly.
 func (ib *InsertBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{}) (sql string, args []interface{}) {
 	buf := &bytes.Buffer{}
-	buf.WriteString(ib.verb)
-	buf.WriteString(" INTO ")
-	buf.WriteString(ib.table)
+
+	if ib.table != "" {
+		buf.WriteString(ib.verb)
+		buf.WriteString(" INTO ")
+		buf.WriteString(ib.table)
+	}
 
 	if len(ib.cols) > 0 {
 		buf.WriteString(" (")
@@ -97,14 +100,17 @@ func (ib *InsertBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{
 		buf.WriteString(")")
 	}
 
-	buf.WriteString(" VALUES ")
-	values := make([]string, 0, len(ib.values))
+	if len(ib.values) > 0 {
+		buf.WriteString(" VALUES ")
+		values := make([]string, 0, len(ib.values))
 
-	for _, v := range ib.values {
-		values = append(values, fmt.Sprintf("(%v)", strings.Join(v, ", ")))
+		for _, v := range ib.values {
+			values = append(values, fmt.Sprintf("(%v)", strings.Join(v, ", ")))
+		}
+
+		buf.WriteString(strings.Join(values, ", "))
 	}
 
-	buf.WriteString(strings.Join(values, ", "))
 	return ib.args.CompileWithFlavor(buf.String(), flavor, initialArg...)
 }
 

--- a/select_test.go
+++ b/select_test.go
@@ -170,3 +170,26 @@ func ExampleSelectBuilder_varInCols() {
 	// SELECT colHasA$Sign, ? FROM table
 	// [foo]
 }
+
+func ExampleSelectBuilder_Exists_Function() {
+	// Column name may contain some characters, e.g. the $ sign, which have special meanings in builders.
+	// It's recommended to call Escape() or EscapeAll() to escape the name.
+
+	sb := NewSelectBuilder()
+	existSb := NewSelectBuilder()
+
+	sb.Select(sb.BuilderFunc(existSb,"EXISTS"))
+
+	existSb.Select("id", "name", sb.As(sb.Func("COUNT", "*"), "c"))
+	existSb.From("user")
+	existSb.Where(existSb.In("status", 1, 2, 5))
+
+
+	sql, args := sb.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// SELECT EXISTS(SELECT id, name, COUNT(*) AS c FROM user WHERE status IN (?, ?, ?))
+	// [1 2 5]
+}

--- a/update.go
+++ b/update.go
@@ -116,10 +116,16 @@ func (ub *UpdateBuilder) Build() (sql string, args []interface{}) {
 // They can be used in `DB#Query` of package `database/sql` directly.
 func (ub *UpdateBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{}) (sql string, args []interface{}) {
 	buf := &bytes.Buffer{}
-	buf.WriteString("UPDATE ")
-	buf.WriteString(ub.table)
-	buf.WriteString(" SET ")
-	buf.WriteString(strings.Join(ub.assignments, ", "))
+
+	if ub.table != "" {
+		buf.WriteString("UPDATE ")
+		buf.WriteString(ub.table)
+	}
+
+	if len(ub.assignments) > 0 {
+		buf.WriteString(" SET ")
+		buf.WriteString(strings.Join(ub.assignments, ", "))
+	}
 
 	if len(ub.whereExprs) > 0 {
 		buf.WriteString(" WHERE ")


### PR DESCRIPTION
Hi,

I have read the doc but there is not something like "Exists" function for a sub query, so I write two functions "Func" and "BuilderFunc" to handle this. Test is wrote in select_test.go and the function name is ExampleSelectBuilder_Exists_Function

Those function will return string 
> FuncName(args...)   
> FuncName(bulder_string)

And also, if someone like me use an orm(gorm,  xorm etc.) but need to handle complex query.
It would be more convenient to use sql builder.

However,  go-sqlbuilder will auto add "SELECT" string even if I don't need it to combine with orm function.

As the result, I modify BuildWithFlavor in select, update, insert and delete with adding more if condition to check some variable is exists.
If the column field is not zerp value, which mean the Select function has been call, and then "SELECT" string will be add.