### PR TITLE
Omitempty for TAG

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/huandu/go-sqlbuilder
+module github.com/tolbier/go-sqlbuilder
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/tolbier/go-sqlbuilder
+module github.com/huandu/go-sqlbuilder
 
 go 1.12

--- a/struct.go
+++ b/struct.go
@@ -115,7 +115,7 @@ func (s *Struct) parse(t reflect.Type) {
 
 		// Parse FieldTag.
 		fieldtag := field.Tag.Get(FieldTag)
-		tags := strings.Split(fieldtag, ",")
+		tags := splitTokens(fieldtag)
 
 		for _, t := range tags {
 			if t != "" {
@@ -140,6 +140,7 @@ func (s *Struct) parse(t reflect.Type) {
 		}
 	}
 }
+
 func (s *Struct) appendOmitEmptyFieldsTags(alias string, tags ...string) {
 	if s.omitEmptyFields[alias] == nil {
 		s.omitEmptyFields[alias] = omitEmptyTagMap{}
@@ -477,11 +478,18 @@ func getOptMatchedMap(opt string) (res map[string]string) {
 	return
 }
 func getTagsFromOptParams(opts string) (tags []string) {
-	tags = strings.Split(opts, ",")
+	tags = splitTokens(opts)
 	if len(tags) == 0 {
 		tags = append(tags, "")
 	}
 	return
+}
+func splitTokens(fieldtag string) (res []string) {
+	res = strings.Split(fieldtag, ",")
+	for i, v := range res {
+		res[i] = strings.TrimSpace(v)
+	}
+	return res
 }
 func dereferencedType(t reflect.Type) reflect.Type {
 	for k := t.Kind(); k == reflect.Ptr || k == reflect.Interface; k = t.Kind() {

--- a/struct.go
+++ b/struct.go
@@ -489,7 +489,7 @@ func splitTokens(fieldtag string) (res []string) {
 	for i, v := range res {
 		res[i] = strings.TrimSpace(v)
 	}
-	return res
+	return
 }
 func dereferencedType(t reflect.Type) reflect.Type {
 	for k := t.Kind(); k == reflect.Ptr || k == reflect.Interface; k = t.Kind() {

--- a/struct.go
+++ b/struct.go
@@ -26,7 +26,7 @@ var (
 const (
 	fieldOptWithQuote         = "withquote"
 	fieldOptOmitEmpty         = "omitempty"
-	fieldOptOmitEmptyForRegex = "omitempty_for_(.+)"
+	fieldOptOmitEmptyForRegex = "^omitempty_for_(.+)$"
 )
 
 // Struct represents a struct type.

--- a/struct.go
+++ b/struct.go
@@ -125,8 +125,9 @@ func (s *Struct) parse(t reflect.Type) {
 		fieldopt := field.Tag.Get(FieldOpt)
 		opts := strings.Split(fieldopt, ",")
 
+		r := regexp.MustCompile(fieldOptOmitEmptyForRegex)
 		for _, opt := range opts {
-			sm := regexp.MustCompile(fieldOptOmitEmptyForRegex).FindStringSubmatch(opt)
+			sm := r.FindStringSubmatch(opt)
 			switch {
 			case sm != nil:
 				s.appendOmitEmptyFieldsTag(alias, sm[1])

--- a/struct_test.go
+++ b/struct_test.go
@@ -647,8 +647,8 @@ func TestStructOmitEmpty(t *testing.T) {
 type structOmitEmptyForTag struct {
 	A int      `db:"aa" fieldopt:"omitempty,withquote" fieldtag:"patch"`
 	B *string  `db:"bb" fieldopt:"omitempty" fieldtag:"patch"`
-	C uint16   `db:"cc" fieldopt:"omitempty" fieldtag:"patch"`
-	D *float64 `fieldopt:"omitempty_for_patch" fieldtag:"patch"`
+	C uint16   `db:"cc" fieldopt:"omitempty()" fieldtag:"patch"`
+	D *float64 `fieldopt:"omitempty(patch)" fieldtag:"patch"`
 	E bool     `db:"ee" fieldtag:"patch"`
 }
 
@@ -682,10 +682,10 @@ func TestStructOmitEmptyForTag(t *testing.T) {
 }
 
 type structOmitEmptyForMultipleTags struct {
-	A int      `db:"aa" fieldopt:"omitempty,withquote" fieldtag:"patch,patch2"`
+	A int      `db:"aa" fieldopt:"omitempty, omitempty(patch,patch2),withquote" fieldtag:"patch,patch2"`
 	B *string  `db:"bb" fieldopt:"omitempty" fieldtag:"patch"`
-	C uint16   `db:"cc" fieldopt:"omitempty, omitempty_for_patch2" fieldtag:"patch2"`
-	D *float64 `fieldopt:"omitempty_for_patch" fieldtag:"patch"`
+	C uint16   `db:"cc" fieldopt:"omitempty, omitempty(patch2)" fieldtag:"patch2"`
+	D *float64 `fieldopt:"omitempty(patch)" fieldtag:"patch"`
 	E bool     `db:"ee" fieldtag:"patch"`
 }
 

--- a/struct_test.go
+++ b/struct_test.go
@@ -682,10 +682,10 @@ func TestStructOmitEmptyForTag(t *testing.T) {
 }
 
 type structOmitEmptyForMultipleTags struct {
-	A int      `db:"aa" fieldopt:"omitempty, omitempty(patch,patch2),withquote" fieldtag:"patch,patch2"`
+	A int      `db:"aa" fieldopt:"omitempty, omitempty(patch, patch2),withquote" fieldtag:"patch, patch2 "`
 	B *string  `db:"bb" fieldopt:"omitempty" fieldtag:"patch"`
 	C uint16   `db:"cc" fieldopt:"omitempty, omitempty(patch2)" fieldtag:"patch2"`
-	D *float64 `fieldopt:"omitempty(patch,patch2)" fieldtag:"patch,patch2"`
+	D *float64 `fieldopt:"omitempty(patch, patch2)" fieldtag:"patch,patch2"`
 	E bool     `db:"ee" fieldtag:"patch"`
 }
 

--- a/struct_test.go
+++ b/struct_test.go
@@ -685,7 +685,7 @@ type structOmitEmptyForMultipleTags struct {
 	A int      `db:"aa" fieldopt:"omitempty, omitempty(patch,patch2),withquote" fieldtag:"patch,patch2"`
 	B *string  `db:"bb" fieldopt:"omitempty" fieldtag:"patch"`
 	C uint16   `db:"cc" fieldopt:"omitempty, omitempty(patch2)" fieldtag:"patch2"`
-	D *float64 `fieldopt:"omitempty(patch)" fieldtag:"patch"`
+	D *float64 `fieldopt:"omitempty(patch,patch2)" fieldtag:"patch,patch2"`
 	E bool     `db:"ee" fieldtag:"patch"`
 }
 


### PR DESCRIPTION
This PR allows to make `omitempty` stuct behavior just on specific calls, determined on runtime, useful for behavior used on API REST PATCH method, and similar.

It allows multiple omitempty_for_TAG, for different TAGs o same struct.

Example: 
with a struct like this:
```
type accountSQL struct {
	ID               string     `db:"id"                      fieldopt:"omitempty"`
	externalID       string     `db:"external_id"`
	FirstName        string     `db:"first_name"              fieldopt:"omitempty_for_patch" fieldtag:"patch"`
	LastName         string     `db:"last_name"               fieldopt:"omitempty_for_patch" fieldtag:"patch"`
	Email            string     `db:"email"                   fieldopt:"omitempty_for_patch" fieldtag:"patch"`
	UpdatedAt        *time.Time `db:"updated_at"              fieldopt:"omitempty"           fieldtag:"patch"`
	CreatedAt        *time.Time `db:"created_at"              fieldopt:"omitempty"`
}
```

* if we call 
```
	sql1, _ := st.Update("foo", new(structOmitEmptyForMultipleTags)).Build()
```
it will `omitempty` for fields: `ID, UpdatedAt, CreatedAt`

* otherwise, if we call 
```
	sql1, _ := st.UpdateForTag("foo", "patch", new(structOmitEmptyForMultipleTags)).Build()
```
it will `omitempty` for all fields but `externalID`

