### PR TITLE
Fix #48 #49 #53: Add new method SQL in all builders

### DIFF
--- a/createtable_test.go
+++ b/createtable_test.go
@@ -7,6 +7,17 @@ import (
 	"fmt"
 )
 
+func ExampleCreateTable() {
+	sql := CreateTable("demo.user").IfNotExists().
+		Define("id", "BIGINT(20)", "NOT NULL", "AUTO_INCREMENT", "PRIMARY KEY", `COMMENT "user id"`).
+		String()
+
+	fmt.Println(sql)
+
+	// Output:
+	// CREATE TABLE IF NOT EXISTS demo.user (id BIGINT(20) NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT "user id")
+}
+
 func ExampleCreateTableBuilder() {
 	ctb := NewCreateTableBuilder()
 	ctb.CreateTable("demo.user").IfNotExists()
@@ -37,4 +48,24 @@ func ExampleCreateTableBuilder_tempTable() {
 
 	// Output:
 	// CREATE TEMPORARY TABLE IF NOT EXISTS demo.user (id BIGINT(20) NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT "user id", name VARCHAR(255) NOT NULL COMMENT "user name", created_at DATETIME NOT NULL COMMENT "user create time", modified_at DATETIME NOT NULL COMMENT "user modify time", KEY idx_name_modified_at name, modified_at) DEFAULT CHARACTER SET utf8mb4
+}
+
+func ExampleCreateTableBuilder_SQL() {
+	ctb := NewCreateTableBuilder()
+	ctb.SQL(`/* before */`)
+	ctb.CreateTempTable("demo.user").IfNotExists()
+	ctb.SQL("/* after create */")
+	ctb.Define("id", "BIGINT(20)", "NOT NULL", "AUTO_INCREMENT", "PRIMARY KEY", `COMMENT "user id"`)
+	ctb.Define("name", "VARCHAR(255)", "NOT NULL", `COMMENT "user name"`)
+	ctb.SQL("/* after define */")
+	ctb.Option("DEFAULT CHARACTER SET", "utf8mb4")
+	ctb.SQL(ctb.Var(Build("AS SELECT * FROM old.user WHERE name LIKE $?", "%Huan%")))
+
+	sql, args := ctb.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// /* before */ CREATE TEMPORARY TABLE IF NOT EXISTS demo.user /* after create */ (id BIGINT(20) NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT "user id", name VARCHAR(255) NOT NULL COMMENT "user name") /* after define */ DEFAULT CHARACTER SET utf8mb4 AS SELECT * FROM old.user WHERE name LIKE ?
+	// [%Huan%]
 }

--- a/delete.go
+++ b/delete.go
@@ -5,7 +5,16 @@ package sqlbuilder
 
 import (
 	"bytes"
+	"strconv"
 	"strings"
+)
+
+const (
+	deleteMarkerInit injectionMarker = iota
+	deleteMarkerAfterDeleteFrom
+	deleteMarkerAfterWhere
+	deleteMarkerAfterOrderBy
+	deleteMarkerAfterLimit
 )
 
 // NewDeleteBuilder creates a new DELETE builder.
@@ -19,7 +28,9 @@ func newDeleteBuilder() *DeleteBuilder {
 		Cond: Cond{
 			Args: args,
 		},
-		args: args,
+		limit:     -1,
+		args:      args,
+		injection: newInjection(),
 	}
 }
 
@@ -27,23 +38,64 @@ func newDeleteBuilder() *DeleteBuilder {
 type DeleteBuilder struct {
 	Cond
 
-	table      string
-	whereExprs []string
+	table       string
+	whereExprs  []string
+	orderByCols []string
+	order       string
+	limit       int
 
 	args *Args
+
+	injection *injection
+	marker    injectionMarker
 }
 
 var _ Builder = new(DeleteBuilder)
 
 // DeleteFrom sets table name in DELETE.
+func DeleteFrom(table string) *DeleteBuilder {
+	return DefaultFlavor.NewDeleteBuilder().DeleteFrom(table)
+}
+
+// DeleteFrom sets table name in DELETE.
 func (db *DeleteBuilder) DeleteFrom(table string) *DeleteBuilder {
 	db.table = Escape(table)
+	db.marker = deleteMarkerAfterDeleteFrom
 	return db
 }
 
 // Where sets expressions of WHERE in DELETE.
 func (db *DeleteBuilder) Where(andExpr ...string) *DeleteBuilder {
 	db.whereExprs = append(db.whereExprs, andExpr...)
+	db.marker = deleteMarkerAfterWhere
+	return db
+}
+
+// OrderBy sets columns of ORDER BY in DELETE.
+func (db *DeleteBuilder) OrderBy(col ...string) *DeleteBuilder {
+	db.orderByCols = col
+	db.marker = deleteMarkerAfterOrderBy
+	return db
+}
+
+// Asc sets order of ORDER BY to ASC.
+func (db *DeleteBuilder) Asc() *DeleteBuilder {
+	db.order = "ASC"
+	db.marker = deleteMarkerAfterOrderBy
+	return db
+}
+
+// Desc sets order of ORDER BY to DESC.
+func (db *DeleteBuilder) Desc() *DeleteBuilder {
+	db.order = "DESC"
+	db.marker = deleteMarkerAfterOrderBy
+	return db
+}
+
+// Limit sets the LIMIT in DELETE.
+func (db *DeleteBuilder) Limit(limit int) *DeleteBuilder {
+	db.limit = limit
+	db.marker = deleteMarkerAfterLimit
 	return db
 }
 
@@ -63,12 +115,35 @@ func (db *DeleteBuilder) Build() (sql string, args []interface{}) {
 // They can be used in `DB#Query` of package `database/sql` directly.
 func (db *DeleteBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{}) (sql string, args []interface{}) {
 	buf := &bytes.Buffer{}
+	db.injection.WriteTo(buf, deleteMarkerInit)
 	buf.WriteString("DELETE FROM ")
 	buf.WriteString(db.table)
+	db.injection.WriteTo(buf, deleteMarkerAfterDeleteFrom)
 
 	if len(db.whereExprs) > 0 {
 		buf.WriteString(" WHERE ")
 		buf.WriteString(strings.Join(db.whereExprs, " AND "))
+
+		db.injection.WriteTo(buf, deleteMarkerAfterWhere)
+	}
+
+	if len(db.orderByCols) > 0 {
+		buf.WriteString(" ORDER BY ")
+		buf.WriteString(strings.Join(db.orderByCols, ", "))
+
+		if db.order != "" {
+			buf.WriteRune(' ')
+			buf.WriteString(db.order)
+		}
+
+		db.injection.WriteTo(buf, deleteMarkerAfterOrderBy)
+	}
+
+	if db.limit >= 0 {
+		buf.WriteString(" LIMIT ")
+		buf.WriteString(strconv.Itoa(db.limit))
+
+		db.injection.WriteTo(buf, deleteMarkerAfterLimit)
 	}
 
 	return db.args.CompileWithFlavor(buf.String(), flavor, initialArg...)
@@ -79,4 +154,10 @@ func (db *DeleteBuilder) SetFlavor(flavor Flavor) (old Flavor) {
 	old = db.args.Flavor
 	db.args.Flavor = flavor
 	return
+}
+
+// SQL adds an arbitrary sql to current position.
+func (db *DeleteBuilder) SQL(sql string) *DeleteBuilder {
+	db.injection.SQL(db.marker, sql)
+	return db
 }

--- a/delete_test.go
+++ b/delete_test.go
@@ -7,6 +7,20 @@ import (
 	"fmt"
 )
 
+func ExampleDeleteFrom() {
+	sql := DeleteFrom("demo.user").
+		Where(
+			"status = 1",
+		).
+		Limit(10).
+		String()
+
+	fmt.Println(sql)
+
+	// Output:
+	// DELETE FROM demo.user WHERE status = 1 LIMIT 10
+}
+
 func ExampleDeleteBuilder() {
 	db := NewDeleteBuilder()
 	db.DeleteFrom("demo.user")
@@ -27,4 +41,27 @@ func ExampleDeleteBuilder() {
 	// Output:
 	// DELETE FROM demo.user WHERE id > ? AND name LIKE ? AND (id_card IS NULL OR status IN (?, ?, ?)) AND modified_at > created_at + ?
 	// [1234 %Du 1 2 5 86400]
+}
+
+func ExampleDeleteBuilder_SQL() {
+	db := NewDeleteBuilder()
+	db.SQL(`/* before */`)
+	db.DeleteFrom("demo.user")
+	db.SQL("PARTITION (p0)")
+	db.Where(
+		db.GreaterThan("id", 1234),
+	)
+	db.SQL("/* after where */")
+	db.OrderBy("id")
+	db.SQL("/* after order by */")
+	db.Limit(10)
+	db.SQL("/* after limit */")
+
+	sql, args := db.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// /* before */ DELETE FROM demo.user PARTITION (p0) WHERE id > ? /* after where */ ORDER BY id /* after order by */ LIMIT 10 /* after limit */
+	// [1234]
 }

--- a/flavor.go
+++ b/flavor.go
@@ -104,16 +104,9 @@ func (f Flavor) NewUpdateBuilder() *UpdateBuilder {
 	return b
 }
 
-// Union unions all builders together using UNION operator with flavor.
-func (f Flavor) Union(builders ...Builder) *UnionBuilder {
-	b := newUnionBuilder(unionDistinct, builders...)
-	b.SetFlavor(f)
-	return b
-}
-
-// UnionAll unions all builders together using UNION ALL operator with flavor.
-func (f Flavor) UnionAll(builders ...Builder) *UnionBuilder {
-	b := newUnionBuilder(unionAll, builders...)
+// NewUnionBuilder creates a new UNION builder with flavor.
+func (f Flavor) NewUnionBuilder() *UnionBuilder {
+	b := newUnionBuilder()
 	b.SetFlavor(f)
 	return b
 }

--- a/injection.go
+++ b/injection.go
@@ -1,0 +1,56 @@
+// Copyright 2018 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package sqlbuilder
+
+import (
+	"bytes"
+	"strings"
+)
+
+// injection is a helper type to manage injected SQLs in all builders.
+type injection struct {
+	markerSQLs map[injectionMarker][]string
+}
+
+type injectionMarker int
+
+type injectedSQL struct {
+	marker injectionMarker
+	sql    string
+}
+
+// newInjection creates a new injection.
+func newInjection() *injection {
+	return &injection{
+		markerSQLs: map[injectionMarker][]string{},
+	}
+}
+
+// SQL adds sql to injection's sql list.
+// All sqls inside injection is ordered by marker in ascending order.
+func (injection *injection) SQL(marker injectionMarker, sql string) {
+	injection.markerSQLs[marker] = append(injection.markerSQLs[marker], sql)
+}
+
+// WriteTo joins all SQL strings at the same marker value with blank (" ")
+// and writes the joined value to buf.
+func (injection *injection) WriteTo(buf *bytes.Buffer, marker injectionMarker) {
+	sqls := injection.markerSQLs[marker]
+	notEmpty := buf.Len() > 0
+
+	if len(sqls) == 0 {
+		return
+	}
+
+	if notEmpty {
+		buf.WriteRune(' ')
+	}
+
+	s := strings.Join(sqls, " ")
+	buf.WriteString(s)
+
+	if !notEmpty {
+		buf.WriteRune(' ')
+	}
+}

--- a/insert.go
+++ b/insert.go
@@ -9,6 +9,13 @@ import (
 	"strings"
 )
 
+const (
+	insertMarkerInit injectionMarker = iota
+	insertMarkerAfterInsertInto
+	insertMarkerAfterCols
+	insertMarkerAfterValues
+)
+
 // NewInsertBuilder creates a new INSERT builder.
 func NewInsertBuilder() *InsertBuilder {
 	return DefaultFlavor.NewInsertBuilder()
@@ -17,8 +24,9 @@ func NewInsertBuilder() *InsertBuilder {
 func newInsertBuilder() *InsertBuilder {
 	args := &Args{}
 	return &InsertBuilder{
-		verb: "INSERT",
-		args: args,
+		verb:      "INSERT",
+		args:      args,
+		injection: newInjection(),
 	}
 }
 
@@ -30,21 +38,42 @@ type InsertBuilder struct {
 	values [][]string
 
 	args *Args
+
+	injection *injection
+	marker    injectionMarker
 }
 
 var _ Builder = new(InsertBuilder)
 
 // InsertInto sets table name in INSERT.
+func InsertInto(table string) *InsertBuilder {
+	return DefaultFlavor.NewInsertBuilder().InsertInto(table)
+}
+
+// InsertInto sets table name in INSERT.
 func (ib *InsertBuilder) InsertInto(table string) *InsertBuilder {
 	ib.table = Escape(table)
+	ib.marker = insertMarkerAfterInsertInto
 	return ib
+}
+
+// InsertIgnoreInto sets table name in INSERT IGNORE.
+func InsertIgnoreInto(table string) *InsertBuilder {
+	return DefaultFlavor.NewInsertBuilder().InsertIgnoreInto(table)
 }
 
 // InsertIgnoreInto sets table name in INSERT IGNORE.
 func (ib *InsertBuilder) InsertIgnoreInto(table string) *InsertBuilder {
 	ib.verb = "INSERT IGNORE"
 	ib.table = Escape(table)
+	ib.marker = insertMarkerAfterInsertInto
 	return ib
+}
+
+// ReplaceInto sets table name and changes the verb of ib to REPLACE.
+// REPLACE INTO is a MySQL extension to the SQL standard.
+func ReplaceInto(table string) *InsertBuilder {
+	return DefaultFlavor.NewInsertBuilder().ReplaceInto(table)
 }
 
 // ReplaceInto sets table name and changes the verb of ib to REPLACE.
@@ -52,12 +81,14 @@ func (ib *InsertBuilder) InsertIgnoreInto(table string) *InsertBuilder {
 func (ib *InsertBuilder) ReplaceInto(table string) *InsertBuilder {
 	ib.verb = "REPLACE"
 	ib.table = Escape(table)
+	ib.marker = insertMarkerAfterInsertInto
 	return ib
 }
 
 // Cols sets columns in INSERT.
 func (ib *InsertBuilder) Cols(col ...string) *InsertBuilder {
 	ib.cols = EscapeAll(col...)
+	ib.marker = insertMarkerAfterCols
 	return ib
 }
 
@@ -70,6 +101,7 @@ func (ib *InsertBuilder) Values(value ...interface{}) *InsertBuilder {
 	}
 
 	ib.values = append(ib.values, placeholders)
+	ib.marker = insertMarkerAfterValues
 	return ib
 }
 
@@ -89,14 +121,18 @@ func (ib *InsertBuilder) Build() (sql string, args []interface{}) {
 // They can be used in `DB#Query` of package `database/sql` directly.
 func (ib *InsertBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{}) (sql string, args []interface{}) {
 	buf := &bytes.Buffer{}
+	ib.injection.WriteTo(buf, insertMarkerInit)
 	buf.WriteString(ib.verb)
 	buf.WriteString(" INTO ")
 	buf.WriteString(ib.table)
+	ib.injection.WriteTo(buf, insertMarkerAfterInsertInto)
 
 	if len(ib.cols) > 0 {
 		buf.WriteString(" (")
 		buf.WriteString(strings.Join(ib.cols, ", "))
 		buf.WriteString(")")
+
+		ib.injection.WriteTo(buf, insertMarkerAfterCols)
 	}
 
 	buf.WriteString(" VALUES ")
@@ -107,6 +143,8 @@ func (ib *InsertBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{
 	}
 
 	buf.WriteString(strings.Join(values, ", "))
+	ib.injection.WriteTo(buf, insertMarkerAfterValues)
+
 	return ib.args.CompileWithFlavor(buf.String(), flavor, initialArg...)
 }
 
@@ -115,4 +153,15 @@ func (ib *InsertBuilder) SetFlavor(flavor Flavor) (old Flavor) {
 	old = ib.args.Flavor
 	ib.args.Flavor = flavor
 	return
+}
+
+// Var returns a placeholder for value.
+func (ib *InsertBuilder) Var(arg interface{}) string {
+	return ib.args.Add(arg)
+}
+
+// SQL adds an arbitrary sql to current position.
+func (ib *InsertBuilder) SQL(sql string) *InsertBuilder {
+	ib.injection.SQL(ib.marker, sql)
+	return ib
 }

--- a/insert_test.go
+++ b/insert_test.go
@@ -7,6 +7,48 @@ import (
 	"fmt"
 )
 
+func ExampleInsertInto() {
+	sql, args := InsertInto("demo.user").
+		Cols("id", "name", "status").
+		Values(4, "Sample", 2).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// INSERT INTO demo.user (id, name, status) VALUES (?, ?, ?)
+	// [4 Sample 2]
+}
+
+func ExampleInsertIgnoreInto() {
+	sql, args := InsertIgnoreInto("demo.user").
+		Cols("id", "name", "status").
+		Values(4, "Sample", 2).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// INSERT IGNORE INTO demo.user (id, name, status) VALUES (?, ?, ?)
+	// [4 Sample 2]
+}
+
+func ExampleReplaceInto() {
+	sql, args := ReplaceInto("demo.user").
+		Cols("id", "name", "status").
+		Values(4, "Sample", 2).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// REPLACE INTO demo.user (id, name, status) VALUES (?, ?, ?)
+	// [4 Sample 2]
+}
+
 func ExampleInsertBuilder() {
 	ib := NewInsertBuilder()
 	ib.InsertInto("demo.user")
@@ -53,4 +95,23 @@ func ExampleInsertBuilder_replaceInto() {
 	// Output:
 	// REPLACE INTO demo.user (id, name, status, created_at) VALUES (?, ?, ?, UNIX_TIMESTAMP(NOW())), (?, ?, ?, ?)
 	// [1 Huan Du 1 2 Charmy Liu 1 1234567890]
+}
+
+func ExampleInsertBuilder_SQL() {
+	ib := NewInsertBuilder()
+	ib.SQL("/* before */")
+	ib.InsertInto("demo.user")
+	ib.SQL("PARTITION (p0)")
+	ib.Cols("id", "name", "status", "created_at")
+	ib.SQL("/* after cols */")
+	ib.Values(3, "Shawn Du", 1, 1234567890)
+	ib.SQL(ib.Var(Build("ON DUPLICATE KEY UPDATE status = $?", 1)))
+
+	sql, args := ib.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// /* before */ INSERT INTO demo.user PARTITION (p0) (id, name, status, created_at) /* after cols */ VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE status = ?
+	// [3 Shawn Du 1 1234567890 1]
 }

--- a/union.go
+++ b/union.go
@@ -14,6 +14,28 @@ const (
 	unionAll      = " UNION ALL "
 )
 
+const (
+	unionMarkerInit injectionMarker = iota
+	unionMarkerAfterUnion
+	unionMarkerAfterOrderBy
+	unionMarkerAfterLimit
+)
+
+// NewUnionBuilder creates a new UNION builder.
+func NewUnionBuilder() *UnionBuilder {
+	return DefaultFlavor.NewUnionBuilder()
+}
+
+func newUnionBuilder() *UnionBuilder {
+	return &UnionBuilder{
+		limit:  -1,
+		offset: -1,
+
+		args:      &Args{},
+		injection: newInjection(),
+	}
+}
+
 // UnionBuilder is a builder to build UNION.
 type UnionBuilder struct {
 	format      string
@@ -24,75 +46,88 @@ type UnionBuilder struct {
 	offset      int
 
 	args *Args
+
+	injection *injection
+	marker    injectionMarker
 }
 
 var _ Builder = new(UnionBuilder)
 
 // Union unions all builders together using UNION operator.
 func Union(builders ...Builder) *UnionBuilder {
-	return DefaultFlavor.Union(builders...)
+	return DefaultFlavor.NewUnionBuilder().Union(builders...)
+}
+
+// Union unions all builders together using UNION operator.
+func (ub *UnionBuilder) Union(builders ...Builder) *UnionBuilder {
+	return ub.union(unionDistinct, builders...)
 }
 
 // UnionAll unions all builders together using UNION ALL operator.
 func UnionAll(builders ...Builder) *UnionBuilder {
-	return DefaultFlavor.UnionAll(builders...)
+	return DefaultFlavor.NewUnionBuilder().UnionAll(builders...)
 }
 
-func newUnionBuilder(opt string, builders ...Builder) *UnionBuilder {
-	args := &Args{}
+// UnionAll unions all builders together using UNION ALL operator.
+func (ub *UnionBuilder) UnionAll(builders ...Builder) *UnionBuilder {
+	return ub.union(unionAll, builders...)
+}
+
+func (ub *UnionBuilder) union(opt string, builders ...Builder) *UnionBuilder {
 	buf := &bytes.Buffer{}
 
 	if len(builders) > 0 {
 		buf.Grow(len(builders) * (4 + len(opt)))
 		buf.WriteRune('(')
-		buf.WriteString(args.Add(builders[0]))
+		buf.WriteString(ub.Var(builders[0]))
 		buf.WriteRune(')')
 
 		for _, b := range builders[1:] {
 			buf.WriteString(opt)
 			buf.WriteRune('(')
-			buf.WriteString(args.Add(b))
+			buf.WriteString(ub.Var(b))
 			buf.WriteRune(')')
 		}
 	}
 
-	return &UnionBuilder{
-		format:   buf.String(),
-		builders: builders,
-		limit:    -1,
-		offset:   -1,
-
-		args: args,
-	}
+	ub.format = buf.String()
+	ub.builders = builders
+	ub.marker = unionMarkerAfterUnion
+	return ub
 }
 
 // OrderBy sets columns of ORDER BY in SELECT.
 func (ub *UnionBuilder) OrderBy(col ...string) *UnionBuilder {
 	ub.orderByCols = col
+	ub.marker = unionMarkerAfterOrderBy
 	return ub
 }
 
 // Asc sets order of ORDER BY to ASC.
 func (ub *UnionBuilder) Asc() *UnionBuilder {
 	ub.order = "ASC"
+	ub.marker = unionMarkerAfterOrderBy
 	return ub
 }
 
 // Desc sets order of ORDER BY to DESC.
 func (ub *UnionBuilder) Desc() *UnionBuilder {
 	ub.order = "DESC"
+	ub.marker = unionMarkerAfterOrderBy
 	return ub
 }
 
 // Limit sets the LIMIT in SELECT.
 func (ub *UnionBuilder) Limit(limit int) *UnionBuilder {
 	ub.limit = limit
+	ub.marker = unionMarkerAfterLimit
 	return ub
 }
 
 // Offset sets the LIMIT offset in SELECT.
 func (ub *UnionBuilder) Offset(offset int) *UnionBuilder {
 	ub.offset = offset
+	ub.marker = unionMarkerAfterLimit
 	return ub
 }
 
@@ -112,7 +147,9 @@ func (ub *UnionBuilder) Build() (sql string, args []interface{}) {
 // They can be used in `DB#Query` of package `database/sql` directly.
 func (ub *UnionBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{}) (sql string, args []interface{}) {
 	buf := &bytes.Buffer{}
+	ub.injection.WriteTo(buf, unionMarkerInit)
 	buf.WriteString(ub.format)
+	ub.injection.WriteTo(buf, unionMarkerAfterUnion)
 
 	if len(ub.orderByCols) > 0 {
 		buf.WriteString(" ORDER BY ")
@@ -122,11 +159,14 @@ func (ub *UnionBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{}
 			buf.WriteRune(' ')
 			buf.WriteString(ub.order)
 		}
+
+		ub.injection.WriteTo(buf, unionMarkerAfterOrderBy)
 	}
 
 	if ub.limit >= 0 {
 		buf.WriteString(" LIMIT ")
 		buf.WriteString(strconv.Itoa(ub.limit))
+
 	}
 
 	if MySQL == flavor && ub.limit >= 0 || PostgreSQL == flavor {
@@ -134,6 +174,10 @@ func (ub *UnionBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{}
 			buf.WriteString(" OFFSET ")
 			buf.WriteString(strconv.Itoa(ub.offset))
 		}
+	}
+
+	if ub.limit >= 0 {
+		ub.injection.WriteTo(buf, unionMarkerAfterLimit)
 	}
 
 	return ub.args.CompileWithFlavor(buf.String(), flavor, initialArg...)
@@ -144,4 +188,15 @@ func (ub *UnionBuilder) SetFlavor(flavor Flavor) (old Flavor) {
 	old = ub.args.Flavor
 	ub.args.Flavor = flavor
 	return
+}
+
+// Var returns a placeholder for value.
+func (ub *UnionBuilder) Var(arg interface{}) string {
+	return ub.args.Add(arg)
+}
+
+// SQL adds an arbitrary sql to current position.
+func (ub *UnionBuilder) SQL(sql string) *UnionBuilder {
+	ub.injection.SQL(ub.marker, sql)
+	return ub
 }

--- a/union_test.go
+++ b/union_test.go
@@ -52,3 +52,28 @@ func ExampleUnionAll() {
 	// (SELECT id, name, created_at FROM demo.user WHERE id > ?) UNION ALL (TABLE demo.user_profile) ORDER BY created_at ASC LIMIT 100 OFFSET 5
 	// [1234]
 }
+
+func ExampleUnionBuilder_SQL() {
+	sb1 := NewSelectBuilder()
+	sb1.Select("id", "name", "created_at")
+	sb1.From("demo.user")
+
+	sb2 := newSelectBuilder()
+	sb2.Select("id", "avatar")
+	sb2.From("demo.user_profile")
+
+	ub := NewUnionBuilder()
+	ub.SQL("/* before */")
+	ub.Union(sb1, sb2)
+	ub.SQL("/* after union */")
+	ub.OrderBy("created_at").Desc()
+	ub.SQL("/* after order by */")
+	ub.Limit(100).Offset(5)
+	ub.SQL("/* after limit */")
+
+	sql := ub.String()
+	fmt.Println(sql)
+
+	// Output:
+	// /* before */ (SELECT id, name, created_at FROM demo.user) UNION (SELECT id, avatar FROM demo.user_profile) /* after union */ ORDER BY created_at DESC /* after order by */ LIMIT 100 OFFSET 5 /* after limit */
+}


### PR DESCRIPTION
All builders add a new method called SQL to enable us to add any arbitrary SQL when building. It's quite useful when we are using some kinds of extension syntax or add special comments in SQL.