### PR TITLE
Ignore unexported fields that are not embedded structs

### DIFF
--- a/struct_test.go
+++ b/struct_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 type structUserForTest struct {
-	ID        int    `db:"id" fieldtag:"important"`
-	Name      string `fieldtag:"important"`
-	Status    int    `db:"status" fieldtag:"important"`
-	CreatedAt int    `db:"created_at"`
+	ID         int    `db:"id" fieldtag:"important"`
+	Name       string `fieldtag:"important"`
+	Status     int    `db:"status" fieldtag:"important"`
+	CreatedAt  int    `db:"created_at"`
+	unexported struct{}
 }
 
 var userForTest = NewStruct(new(structUserForTest))

--- a/structfields.go
+++ b/structfields.go
@@ -51,6 +51,11 @@ func (sf *structFields) parse(t reflect.Type, mapper FieldMapperFunc, prefix str
 	for i := 0; i < l; i++ {
 		field := t.Field(i)
 
+		// Skip unexported fields that are not embedded structs.
+		if !field.IsExported() && !field.Anonymous {
+			continue
+		}
+
 		if field.Anonymous {
 			ft := field.Type
 


### PR DESCRIPTION
If a struct passed to the NewStruct contains an unexported field, `sqlbuilder` will panic with the following message: `cannot return value obtained from unexported field or method`. Given that the documentation says that unexported fields should not be visible to NewStruct, this looks like a bug to me. This PR fixes this.