### PR TITLE
Add insert ignore support for postgres and sqlite

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -64,9 +64,7 @@ func InsertIgnoreInto(table string) *InsertBuilder {
 
 // InsertIgnoreInto sets table name in INSERT IGNORE.
 func (ib *InsertBuilder) InsertIgnoreInto(table string) *InsertBuilder {
-	ib.verb = "INSERT IGNORE"
-	ib.table = Escape(table)
-	ib.marker = insertMarkerAfterInsertInto
+	ib.args.Flavor.PrepareInsertIgnore(table, ib)
 	return ib
 }
 

--- a/insert_test.go
+++ b/insert_test.go
@@ -93,7 +93,7 @@ func ExampleInsertBuilder_insertIgnore_postgres() {
 	fmt.Println(args)
 
 	// Output:
-	// INSERT INTO demo.user (id,name,status,created_at) VALUES ($1,$2,$3,UNIX_TIMESTAMP(NOW())),($4,$5,$6,$7) ON CONFLICT DO NOTHING
+	// INSERT INTO demo.user (id, name, status, created_at) VALUES ($1, $2, $3, UNIX_TIMESTAMP(NOW())), ($4, $5, $6, $7) ON CONFLICT DO NOTHING
 	// [1 Huan Du 1 2 Charmy Liu 1 1234567890]
 }
 
@@ -109,7 +109,7 @@ func ExampleInsertBuilder_insertIgnore_sqlite() {
 	fmt.Println(args)
 
 	// Output:
-	// INSERT OR IGNORE INTO demo.user (id,name,status,created_at) VALUES (?,?,?,UNIX_TIMESTAMP(NOW())),(?,?,?,?)
+	// INSERT OR IGNORE INTO demo.user (id, name, status, created_at) VALUES (?, ?, ?, UNIX_TIMESTAMP(NOW())), (?, ?, ?, ?)
 	// [1 Huan Du 1 2 Charmy Liu 1 1234567890]
 }
 

--- a/insert_test.go
+++ b/insert_test.go
@@ -81,6 +81,38 @@ func ExampleInsertBuilder_insertIgnore() {
 	// [1 Huan Du 1 2 Charmy Liu 1 1234567890]
 }
 
+func ExampleInsertBuilder_insertIgnore_postgres() {
+	ib := PostgreSQL.NewInsertBuilder()
+	ib.InsertIgnoreInto("demo.user")
+	ib.Cols("id", "name", "status", "created_at")
+	ib.Values(1, "Huan Du", 1, Raw("UNIX_TIMESTAMP(NOW())"))
+	ib.Values(2, "Charmy Liu", 1, 1234567890)
+
+	sql, args := ib.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// INSERT INTO demo.user (id,name,status,created_at) VALUES ($1,$2,$3,UNIX_TIMESTAMP(NOW())),($4,$5,$6,$7) ON CONFLICT DO NOTHING
+	// [1 Huan Du 1 2 Charmy Liu 1 1234567890]
+}
+
+func ExampleInsertBuilder_insertIgnore_sqlite() {
+	ib := SQLite.NewInsertBuilder()
+	ib.InsertIgnoreInto("demo.user")
+	ib.Cols("id", "name", "status", "created_at")
+	ib.Values(1, "Huan Du", 1, Raw("UNIX_TIMESTAMP(NOW())"))
+	ib.Values(2, "Charmy Liu", 1, 1234567890)
+
+	sql, args := ib.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// INSERT OR IGNORE INTO demo.user (id,name,status,created_at) VALUES (?,?,?,UNIX_TIMESTAMP(NOW())),(?,?,?,?)
+	// [1 Huan Du 1 2 Charmy Liu 1 1234567890]
+}
+
 func ExampleInsertBuilder_replaceInto() {
 	ib := NewInsertBuilder()
 	ib.ReplaceInto("demo.user")


### PR DESCRIPTION
### Summary
Add insert ignore support for postgres and sqlite. 

For pg, this is `ON CONFLICT DO NOTHING`, for sqlite it's `INSERT OR IGNORE`

- https://www.postgresql.org/docs/current/sql-insert.html
- https://www.sqlite.org/lang_insert.html

### Testing
- Added new unit tests
- Tested against local postgres server using this library (changes in another private repo)
- Manually tested sqlite query on https://sqliteonline.com/
