### PR TITLE
Add helper Args() []interface function to get all builder arguments

### DIFF
--- a/createtable.go
+++ b/createtable.go
@@ -85,7 +85,12 @@ func (ctb *CreateTableBuilder) Option(opt ...string) *CreateTableBuilder {
 	return ctb
 }
 
-// String returns the compiled INSERT string.
+// Args returns all arguments for the compiled CREATE TABLE builder.
+func (ctb *CreateTableBuilder) Args() []interface{} {
+	return ctb.args.args
+}
+
+// String returns the compiled CREATE TABLE string.
 func (ctb *CreateTableBuilder) String() string {
 	s, _ := ctb.Build()
 	return s

--- a/createtable.go
+++ b/createtable.go
@@ -87,7 +87,8 @@ func (ctb *CreateTableBuilder) Option(opt ...string) *CreateTableBuilder {
 
 // Args returns all arguments for the compiled CREATE TABLE builder.
 func (ctb *CreateTableBuilder) Args() []interface{} {
-	return ctb.args.args
+	_, args := ctb.Build()
+	return args
 }
 
 // String returns the compiled CREATE TABLE string.

--- a/delete.go
+++ b/delete.go
@@ -98,6 +98,11 @@ func (db *DeleteBuilder) Limit(limit int) *DeleteBuilder {
 	return db
 }
 
+// Args returns all arguments for the compiled DELETE builder.
+func (db *DeleteBuilder) Args() []interface{} {
+	return db.args.args
+}
+
 // String returns the compiled DELETE string.
 func (db *DeleteBuilder) String() string {
 	s, _ := db.Build()

--- a/delete.go
+++ b/delete.go
@@ -100,7 +100,8 @@ func (db *DeleteBuilder) Limit(limit int) *DeleteBuilder {
 
 // Args returns all arguments for the compiled DELETE builder.
 func (db *DeleteBuilder) Args() []interface{} {
-	return db.args.args
+	_, args := db.Build()
+	return args
 }
 
 // String returns the compiled DELETE string.

--- a/insert.go
+++ b/insert.go
@@ -112,6 +112,11 @@ func (ib *InsertBuilder) Values(value ...interface{}) *InsertBuilder {
 	return ib
 }
 
+// Args returns all arguments for the compiled INSERT builder.
+func (ib *InsertBuilder) Args() []interface{} {
+	return ib.args.args
+}
+
 // String returns the compiled INSERT string.
 func (ib *InsertBuilder) String() string {
 	s, _ := ib.Build()

--- a/insert.go
+++ b/insert.go
@@ -114,7 +114,8 @@ func (ib *InsertBuilder) Values(value ...interface{}) *InsertBuilder {
 
 // Args returns all arguments for the compiled INSERT builder.
 func (ib *InsertBuilder) Args() []interface{} {
-	return ib.args.args
+	_, args := ib.Build()
+	return args
 }
 
 // String returns the compiled INSERT string.

--- a/select.go
+++ b/select.go
@@ -219,6 +219,11 @@ func (sb *SelectBuilder) BuilderAs(builder Builder, alias string) string {
 	return fmt.Sprintf("(%s) AS %s", sb.Var(builder), alias)
 }
 
+// Args returns all arguments for the compiled SELECT builder.
+func (sb *SelectBuilder) Args() []interface{} {
+	return sb.args.args
+}
+
 // String returns the compiled SELECT string.
 func (sb *SelectBuilder) String() string {
 	s, _ := sb.Build()

--- a/select.go
+++ b/select.go
@@ -221,7 +221,8 @@ func (sb *SelectBuilder) BuilderAs(builder Builder, alias string) string {
 
 // Args returns all arguments for the compiled SELECT builder.
 func (sb *SelectBuilder) Args() []interface{} {
-	return sb.args.args
+	_, args := sb.Build()
+	return args
 }
 
 // String returns the compiled SELECT string.

--- a/union.go
+++ b/union.go
@@ -114,6 +114,11 @@ func (ub *UnionBuilder) Offset(offset int) *UnionBuilder {
 	return ub
 }
 
+// Args returns all arguments for the compiled SELECT builder.
+func (ub *UnionBuilder) Args() []interface{} {
+	return ub.args.args
+}
+
 // String returns the compiled SELECT string.
 func (ub *UnionBuilder) String() string {
 	s, _ := ub.Build()

--- a/union.go
+++ b/union.go
@@ -116,7 +116,8 @@ func (ub *UnionBuilder) Offset(offset int) *UnionBuilder {
 
 // Args returns all arguments for the compiled SELECT builder.
 func (ub *UnionBuilder) Args() []interface{} {
-	return ub.args.args
+	_, args := ub.Build()
+	return args
 }
 
 // String returns the compiled SELECT string.

--- a/update.go
+++ b/update.go
@@ -158,7 +158,8 @@ func (ub *UpdateBuilder) Limit(limit int) *UpdateBuilder {
 
 // Args returns all arguments for the compiled UPDATE builder.
 func (ub *UpdateBuilder) Args() []interface{} {
-	return ub.args.args
+	_, args := ub.Build()
+	return args
 }
 
 // String returns the compiled UPDATE string.

--- a/update.go
+++ b/update.go
@@ -156,6 +156,11 @@ func (ub *UpdateBuilder) Limit(limit int) *UpdateBuilder {
 	return ub
 }
 
+// Args returns all arguments for the compiled UPDATE builder.
+func (ub *UpdateBuilder) Args() []interface{} {
+	return ub.args.args
+}
+
 // String returns the compiled UPDATE string.
 func (ub *UpdateBuilder) String() string {
 	s, _ := ub.Build()


### PR DESCRIPTION
The main goal of this function is to provide a helper function to get all builder arguments like with `String() string` function.

Why did I come up with this solution? If you use `Struct` builder with `omitempty` tags and also you use `WHERE` clause you may get into a trap when you don't have any update arguments, but you have arguments in `WHERE` clause:
```sql
UPDATE s_table WHERE id = $1; # will get an error
```

To solve this problem and to understand if you really have arguments in the update part, you should build statement and then check `if len(args) != 0` before `WHERE` statement.
```go
func main() {
	toUpdate := S{} // empty fields
	b := ss.Update("s_table", toUpdate)
	q, args := b.Build()
	if len(args) != 0 {
		// Process this update
	}
}
```

But it would be more convenient to use `Args` function:

```go
type S struct {
	ID   int    `db:"id" fieldopt:"omitempty"`
	Name string `db:"name" fieldopt"name"`
}

var ss = sqlb.NewStruct(new(S))

func main() {
	p := S{}
	ub := ss.Update("s_table", p)

	if len(ub.Args()) != 0 {

	}
}
```

Also, I understand that there is a good chance to implement a cache builder mechanism to prevent building every time we call `String() string` or `Args() []interface` methods. But at the time I don't have enough information to implement this. 