### PR TITLE
Add SetConditions and GetConditions methods to DeleteBuilder, SelectB…

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -164,3 +164,15 @@ func (db *DeleteBuilder) SQL(sql string) *DeleteBuilder {
 	db.injection.SQL(db.marker, sql)
 	return db
 }
+
+// Set WhereExprs and Args from another builder
+func (db *DeleteBuilder) SetConditions(whereExprs []string, args Args) *DeleteBuilder {
+	db.whereExprs = whereExprs
+	*db.args = args
+	return db
+}
+
+// GetConditions returns the current WHERE expressions and Args.
+func (db *DeleteBuilder) GetConditions() ([]string, Args) {
+	return db.whereExprs, *db.Cond.Args
+}

--- a/select.go
+++ b/select.go
@@ -475,3 +475,15 @@ func (sb *SelectBuilder) SQL(sql string) *SelectBuilder {
 	sb.injection.SQL(sb.marker, sql)
 	return sb
 }
+
+// Set WhereExprs and Args from another builder
+func (sb *SelectBuilder) SetConditions(whereExprs []string, args Args) *SelectBuilder {
+	sb.whereExprs = whereExprs
+	*sb.args = args
+	return sb
+}
+
+// GetConditions returns the current WHERE expressions and Args.
+func (sb *SelectBuilder) GetConditions() ([]string, Args) {
+	return sb.whereExprs, *sb.Cond.Args
+}

--- a/update.go
+++ b/update.go
@@ -232,3 +232,15 @@ func (ub *UpdateBuilder) SQL(sql string) *UpdateBuilder {
 	ub.injection.SQL(ub.marker, sql)
 	return ub
 }
+
+// Set WhereExprs and Args from another builder
+func (ub *UpdateBuilder) SetConditions(whereExprs []string, arg Args) *UpdateBuilder {
+	ub.whereExprs = whereExprs
+	*ub.args = arg
+	return ub
+}
+
+// GetConditions returns the current WHERE expressions and Args.
+func (ub *UpdateBuilder) GetConditions() ([]string, Args) {
+	return ub.whereExprs, *ub.args
+}


### PR DESCRIPTION
Hi, i am building a package on top of this one
This is based multi-layer cache library that uses redis and some other in-memory library.The problem occurs when I need to clear the cache first to ensure related keys are also deleted at the same time. So I need to transfer the conditional statement of the delete  builder to select builder to be able to select the records that need to be deleted from the cache
```
func (r *BaseDAO[T]) DeleteBy(query func(query *sqlbuilder.DeleteBuilder)) error {
	if len(r.DaoLayers) > 1 {
		datas := r.DaoLayers[len(r.DaoLayers)-1].GetAll(func(q *sqlbuilder.SelectBuilder) {
			deleteQuery := flavor.NewDeleteBuilder()
			query(deleteQuery)
			q.SetConditions(deleteQuery.GetConditions())
		})
		for i := 0; i < len(datas); i++ {
			for i := len(r.DaoLayers) - 2; i >= 0; i-- {
				err := r.DaoLayers[i].deleteByID(r.GetID(datas[i]), datas[i])
				if err != nil {
					v_log.V(1).Errorf("BaseDAO::UpdateMultiple - Error deleting cache in layer: %s - %v", r.DaoLayers[i].LayerName(), err)
				}
			}
			go r.PublishDeletedEvent(datas[i])
		}
	}

	if err := r.DaoLayers[len(r.DaoLayers)-1].DeleteBy(query); err != nil {
		v_log.V(1).Errorf("BaseDAO::DeleteBy - Error deleting data in db: %v", err)
		return err
	}

	return nil
}
```