### PR TITLE
`WhereClause`: A new dedicated builder for WHERE

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@
   - [Freestyle builder](#freestyle-builder)
   - [Using special syntax to build SQL](#using-special-syntax-to-build-sql)
   - [Interpolate `args` in the `sql`](#interpolate-args-in-the-sql)
-- [FAQ](#faq)
-  - [What's the difference between this package and `squirrel`](#whats-the-difference-between-this-package-and-squirrel)
 - [License](#license)
 
-Package `sqlbuilder` provides a set of flexible and powerful SQL string builders. The only goal of this package is to build SQL string with arguments which can be used in `DB#Query` or `DB#Exec` defined in package `database/sql`.
+The `sqlbuilder` package implements a series of flexible and powerful SQL string concatenation builders. This package focuses on constructing SQL strings for direct use with the Go standard library's `sql.DB` and `sql.Stmt` related interfaces, and strives to optimize the performance of building SQL and reduce memory consumption.
+
+The initial goal in designing this package was to create a pure SQL construction library that is independent of specific database drivers and business logic. It is designed to meet the needs of enterprise-level scenarios that require various customized database drivers, special operation and maintenance standards, heterogeneous systems, and non-standard SQL in complex situations. Since its open-source inception, this package has been tested in a large enterprise-level application scenario, enduring the pressure of hundreds of millions of orders daily and nearly ten million transactions per day, demonstrating good performance and scalability.
+
+This package does not bind to any specific database driver, nor does it automatically connect to any database. It does not even assume the use of the generated SQL, making it suitable for any application scenario that constructs SQL-like statements. It is also very suitable for secondary development on this basis, to implement more business-related database access packages, ORMs, and so on.
 
 ## Install
 
@@ -193,7 +195,7 @@ fmt.Println(ub)
 // UPDATE users SET level = level + ? WHERE id = ?
 ```
 
-The `WhereClause` is not thread-safe. Read samples for [WhereClause](https://pkg.go.dev/github.com/huandu/go-sqlbuilder#WhereClause) to learn how to use it correctly.
+Read samples for [WhereClause](https://pkg.go.dev/github.com/huandu/go-sqlbuilder#WhereClause) to learn how to use it.
 
 ### Build SQL for different systems
 
@@ -405,7 +407,9 @@ If we just want to use `${name}` syntax to refer named arguments, use `BuildName
 
 ### Interpolate `args` in the `sql`
 
-Some SQL drivers doesn't actually implement `StmtExecContext#ExecContext`. They will fail when `len(args) > 0`. The only solution is to interpolate `args` in the `sql`, and execute the interpolated query with the driver.
+Some SQL-like drivers, e.g. SQL for Redis, SQL for ES, etc., doesn't actually implement `StmtExecContext#ExecContext`. They will fail when `len(args) > 0`. The only solution is to interpolate `args` in the `sql`, and execute the interpolated query with the driver.
+
+The design goal of the interpolation feature in this package is to implement a "basically sufficient" capability, rather than a feature that is on par with various SQL drivers and DBMS systems.
 
 _Security warning_: I try my best to escape special characters in interpolate methods, but it's still less secure than `Stmt` implemented by SQL servers.
 
@@ -457,19 +461,6 @@ fmt.Println(err)
 // SELECT * FROM dup(42);
 // <nil>
 ```
-
-## FAQ
-
-### What's the difference between this package and `squirrel`
-
-Package [squirrel](https://github.com/Masterminds/squirrel) is another SQL builder package with outstanding design and high code quality.
-Comparing with `squirrel`, `go-sqlbuilder` is much more extensible with more built-in features.
-
-Here are details.
-
-- API design: The core of `go-sqlbuilder` is `Builder` and `Args`. Nearly all features are built on top of them. If we want to extend this package, e.g. support `EXPLAIN`, we can use `Build("EXPLAIN $?", builder)` to add `EXPLAIN` in front of any SQL.
-- ORM: Package `squirrel` doesn't provide ORM directly. There is another package [structable](https://github.com/Masterminds/structable), which is based on `squirrel`, designed for ORM.
-- No design pitfalls: There is no design pitfalls like `squirrel.Eq{"mynumber": []uint8{1,2,3}}`. I'm proud of it. :)
 
 ## License
 

--- a/cond.go
+++ b/cond.go
@@ -3,13 +3,16 @@
 
 package sqlbuilder
 
-import (
-	"strings"
-)
-
 // Cond provides several helper methods to build conditions.
 type Cond struct {
 	Args *Args
+}
+
+// NewCond returns a new Cond.
+func NewCond() *Cond {
+	return &Cond{
+		Args: &Args{},
+	}
 }
 
 // Equal represents "field = value".
@@ -137,7 +140,7 @@ func (c *Cond) In(field string, value ...interface{}) string {
 	buf := newStringBuilder()
 	buf.WriteString(Escape(field))
 	buf.WriteString(" IN (")
-	buf.WriteString(strings.Join(vs, ", "))
+	buf.WriteStrings(vs, ", ")
 	buf.WriteString(")")
 	return buf.String()
 }
@@ -153,7 +156,7 @@ func (c *Cond) NotIn(field string, value ...interface{}) string {
 	buf := newStringBuilder()
 	buf.WriteString(Escape(field))
 	buf.WriteString(" NOT IN (")
-	buf.WriteString(strings.Join(vs, ", "))
+	buf.WriteStrings(vs, ", ")
 	buf.WriteString(")")
 	return buf.String()
 }
@@ -218,7 +221,7 @@ func (c *Cond) NotBetween(field string, lower, upper interface{}) string {
 func (c *Cond) Or(orExpr ...string) string {
 	buf := newStringBuilder()
 	buf.WriteString("(")
-	buf.WriteString(strings.Join(orExpr, " OR "))
+	buf.WriteStrings(orExpr, " OR ")
 	buf.WriteString(")")
 	return buf.String()
 }
@@ -227,7 +230,7 @@ func (c *Cond) Or(orExpr ...string) string {
 func (c *Cond) And(andExpr ...string) string {
 	buf := newStringBuilder()
 	buf.WriteString("(")
-	buf.WriteString(strings.Join(andExpr, " AND "))
+	buf.WriteStrings(andExpr, " AND ")
 	buf.WriteString(")")
 	return buf.String()
 }
@@ -263,7 +266,7 @@ func (c *Cond) Any(field, op string, value ...interface{}) string {
 	buf.WriteString(" ")
 	buf.WriteString(op)
 	buf.WriteString(" ANY (")
-	buf.WriteString(strings.Join(vs, ", "))
+	buf.WriteStrings(vs, ", ")
 	buf.WriteString(")")
 	return buf.String()
 }
@@ -281,7 +284,7 @@ func (c *Cond) All(field, op string, value ...interface{}) string {
 	buf.WriteString(" ")
 	buf.WriteString(op)
 	buf.WriteString(" ALL (")
-	buf.WriteString(strings.Join(vs, ", "))
+	buf.WriteStrings(vs, ", ")
 	buf.WriteString(")")
 	return buf.String()
 }
@@ -299,7 +302,7 @@ func (c *Cond) Some(field, op string, value ...interface{}) string {
 	buf.WriteString(" ")
 	buf.WriteString(op)
 	buf.WriteString(" SOME (")
-	buf.WriteString(strings.Join(vs, ", "))
+	buf.WriteStrings(vs, ", ")
 	buf.WriteString(")")
 	return buf.String()
 }

--- a/createtable.go
+++ b/createtable.go
@@ -131,7 +131,7 @@ func (ctb *CreateTableBuilder) BuildWithFlavor(flavor Flavor, initialArg ...inte
 			defs = append(defs, strings.Join(def, " "))
 		}
 
-		buf.WriteString(strings.Join(defs, ", "))
+		buf.WriteStrings(defs, ", ")
 		buf.WriteRune(')')
 
 		ctb.injection.WriteTo(buf, createTableMarkerAfterDefine)

--- a/injection.go
+++ b/injection.go
@@ -3,10 +3,6 @@
 
 package sqlbuilder
 
-import (
-	"strings"
-)
-
 // injection is a helper type to manage injected SQLs in all builders.
 type injection struct {
 	markerSQLs map[injectionMarker][]string
@@ -36,6 +32,6 @@ func (injection *injection) WriteTo(buf *stringBuilder, marker injectionMarker) 
 		return
 	}
 
-	s := strings.Join(sqls, " ")
-	buf.WriteLeadingString(s)
+	buf.WriteLeadingString("")
+	buf.WriteStrings(sqls, " ")
 }

--- a/insert.go
+++ b/insert.go
@@ -147,7 +147,7 @@ func (ib *InsertBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{
 			ib.injection.WriteTo(buf, insertMarkerAfterInsertInto)
 			if len(ib.cols) > 0 {
 				buf.WriteLeadingString("(")
-				buf.WriteString(strings.Join(ib.cols, ", "))
+				buf.WriteStrings(ib.cols, ", ")
 				buf.WriteString(")")
 
 				ib.injection.WriteTo(buf, insertMarkerAfterCols)
@@ -156,7 +156,7 @@ func (ib *InsertBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{
 			buf.WriteLeadingString("VALUES ")
 			values := make([]string, 0, len(ib.values))
 			values = append(values, fmt.Sprintf("(%v)", strings.Join(v, ", ")))
-			buf.WriteString(strings.Join(values, ", "))
+			buf.WriteStrings(values, ", ")
 		}
 
 		buf.WriteString(" SELECT 1 from DUAL")
@@ -176,7 +176,7 @@ func (ib *InsertBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{
 
 	if len(ib.cols) > 0 {
 		buf.WriteLeadingString("(")
-		buf.WriteString(strings.Join(ib.cols, ", "))
+		buf.WriteStrings(ib.cols, ", ")
 		buf.WriteString(")")
 
 		ib.injection.WriteTo(buf, insertMarkerAfterCols)
@@ -198,7 +198,7 @@ func (ib *InsertBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{
 			values = append(values, fmt.Sprintf("(%v)", strings.Join(v, ", ")))
 		}
 
-		buf.WriteString(strings.Join(values, ", "))
+		buf.WriteStrings(values, ", ")
 	}
 
 	ib.injection.WriteTo(buf, insertMarkerAfterValues)

--- a/modifiers.go
+++ b/modifiers.go
@@ -101,9 +101,9 @@ func Tuple(values ...interface{}) interface{} {
 // TupleNames joins names with tuple format.
 // The names is not escaped. Use `EscapeAll` to escape them if necessary.
 func TupleNames(names ...string) string {
-	buf := &strings.Builder{}
+	buf := newStringBuilder()
 	buf.WriteRune('(')
-	buf.WriteString(strings.Join(names, ", "))
+	buf.WriteStrings(names, ", ")
 	buf.WriteRune(')')
 
 	return buf.String()

--- a/stringbuilder.go
+++ b/stringbuilder.go
@@ -34,6 +34,19 @@ func (sb *stringBuilder) WriteString(s string) {
 	sb.builder.WriteString(s)
 }
 
+func (sb *stringBuilder) WriteStrings(ss []string, sep string) {
+	if len(ss) == 0 {
+		return
+	}
+
+	sb.WriteString(ss[0])
+
+	for _, s := range ss[1:] {
+		sb.WriteString(sep)
+		sb.WriteString(s)
+	}
+}
+
 func (sb *stringBuilder) WriteRune(r rune) {
 	sb.builder.WriteRune(r)
 }

--- a/union.go
+++ b/union.go
@@ -5,7 +5,6 @@ package sqlbuilder
 
 import (
 	"strconv"
-	"strings"
 )
 
 const (
@@ -162,7 +161,7 @@ func (ub *UnionBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{}
 
 	if len(ub.orderByCols) > 0 {
 		buf.WriteLeadingString("ORDER BY ")
-		buf.WriteString(strings.Join(ub.orderByCols, ", "))
+		buf.WriteStrings(ub.orderByCols, ", ")
 
 		if ub.order != "" {
 			buf.WriteRune(' ')

--- a/update_test.go
+++ b/update_test.go
@@ -59,10 +59,10 @@ func TestUpdateAssignments(t *testing.T) {
 	cases := map[string]func(ub *UpdateBuilder) string{
 		"f = f + 1|[]":     func(ub *UpdateBuilder) string { return ub.Incr("f") },
 		"f = f - 1|[]":     func(ub *UpdateBuilder) string { return ub.Decr("f") },
-		"f = f + $0|[123]": func(ub *UpdateBuilder) string { return ub.Add("f", 123) },
-		"f = f - $0|[123]": func(ub *UpdateBuilder) string { return ub.Sub("f", 123) },
-		"f = f * $0|[123]": func(ub *UpdateBuilder) string { return ub.Mul("f", 123) },
-		"f = f / $0|[123]": func(ub *UpdateBuilder) string { return ub.Div("f", 123) },
+		"f = f + $1|[123]": func(ub *UpdateBuilder) string { return ub.Add("f", 123) },
+		"f = f - $1|[123]": func(ub *UpdateBuilder) string { return ub.Sub("f", 123) },
+		"f = f * $1|[123]": func(ub *UpdateBuilder) string { return ub.Mul("f", 123) },
+		"f = f / $1|[123]": func(ub *UpdateBuilder) string { return ub.Div("f", 123) },
 	}
 
 	for expected, f := range cases {

--- a/whereclause.go
+++ b/whereclause.go
@@ -1,0 +1,114 @@
+// Copyright 2018 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package sqlbuilder
+
+// WhereClause is a Builder for WHERE clause.
+// All builders which support `WHERE` clause have an anonymous `WhereClause` field,
+// in which the conditions are stored.
+//
+// WhereClause can be shared among multiple builders.
+// However, it is not thread-safe.
+type WhereClause struct {
+	flavor  Flavor
+	clauses []clause
+}
+
+var _ Builder = new(WhereClause)
+
+// NewWhereClause creates a new WhereClause.
+func NewWhereClause() *WhereClause {
+	return &WhereClause{}
+}
+
+// CopyWhereClause creates a copy of the whereClause.
+func CopyWhereClause(whereClause *WhereClause) *WhereClause {
+	clauses := make([]clause, len(whereClause.clauses))
+	copy(clauses, whereClause.clauses)
+
+	return &WhereClause{
+		flavor:  whereClause.flavor,
+		clauses: clauses,
+	}
+}
+
+type clause struct {
+	args     *Args
+	andExprs []string
+}
+
+func (c *clause) Build(flavor Flavor, initialArg ...interface{}) (sql string, args []interface{}) {
+	buf := newStringBuilder()
+	buf.WriteStrings(c.andExprs, " AND ")
+	sql, args = c.args.CompileWithFlavor(buf.String(), flavor, initialArg...)
+	return
+}
+
+// whereClauseProxy is a proxy for WhereClause.
+// It's useful when the WhereClause in a build can be changed.
+type whereClauseProxy struct {
+	*WhereClause
+}
+
+var _ Builder = new(whereClauseProxy)
+
+// BuildWithFlavor builds a WHERE clause with the specified flavor and initial arguments.
+func (wc *WhereClause) BuildWithFlavor(flavor Flavor, initialArg ...interface{}) (sql string, args []interface{}) {
+	if len(wc.clauses) == 0 {
+		return "", nil
+	}
+
+	buf := newStringBuilder()
+	buf.WriteLeadingString("WHERE ")
+
+	sql, args = wc.clauses[0].Build(flavor, initialArg...)
+	buf.WriteString(sql)
+
+	for _, clause := range wc.clauses[1:] {
+		buf.WriteString(" AND ")
+		sql, args = clause.Build(flavor, args...)
+		buf.WriteString(sql)
+	}
+
+	return buf.String(), args
+}
+
+// Build returns compiled WHERE clause string and args.
+func (wc *WhereClause) Build() (sql string, args []interface{}) {
+	return wc.BuildWithFlavor(wc.flavor)
+}
+
+// SetFlavor sets the flavor of compiled sql.
+// When the WhereClause belongs to a builder, the flavor of the builder will be used when building SQL.
+func (wc *WhereClause) SetFlavor(flavor Flavor) (old Flavor) {
+	old = wc.flavor
+	wc.flavor = flavor
+	return
+}
+
+// AddWhereExpr adds an AND expression to WHERE clause with the specified arguments.
+func (wc *WhereClause) AddWhereExpr(args *Args, andExpr ...string) {
+	// Merge with last clause if possible.
+	if len(wc.clauses) > 0 {
+		lastClause := &wc.clauses[len(wc.clauses)-1]
+
+		if lastClause.args == args {
+			lastClause.andExprs = append(lastClause.andExprs, andExpr...)
+			return
+		}
+	}
+
+	wc.clauses = append(wc.clauses, clause{
+		args:     args,
+		andExprs: andExpr,
+	})
+}
+
+// AddWhereClause adds all clauses in the whereClause to the wc.
+func (wc *WhereClause) AddWhereClause(whereClause *WhereClause) {
+	if whereClause == nil {
+		return
+	}
+
+	wc.clauses = append(wc.clauses, whereClause.clauses...)
+}

--- a/whereclause_test.go
+++ b/whereclause_test.go
@@ -1,0 +1,190 @@
+// Copyright 2018 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package sqlbuilder
+
+import (
+	"fmt"
+)
+
+func ExampleWhereClause() {
+	// Build a SQL to select a user from database.
+	sb := Select("name", "level").From("users")
+	sb.Where(
+		sb.Equal("id", 1234),
+	)
+	sql, args := sb.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Query database with the sql and update this user's level...
+
+	ub := Update("users")
+	ub.Set(
+		ub.Add("level", 10),
+	)
+
+	// The WHERE clause of UPDATE should be the same as the WHERE clause of SELECT.
+	ub.WhereClause = sb.WhereClause
+
+	sql, args = ub.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// SELECT name, level FROM users WHERE id = ?
+	// [1234]
+	// UPDATE users SET level = level + ? WHERE id = ?
+	// [10 1234]
+}
+
+func ExampleWhereClause_sharedAmongBuilders() {
+	// A WhereClause can be shared among builders.
+	// However, as it's not thread-safe, don't use it in a concurrent environment.
+	sb1 := Select("level").From("users")
+	sb2 := Select("status").From("users")
+
+	// Share the same WhereClause between sb1 and sb2.
+	whereClause := NewWhereClause()
+	sb1.WhereClause = whereClause
+	sb2.WhereClause = whereClause
+
+	// The Where method in sb1 and sb2 will update the same WhereClause.
+	// When we call sb1.Where(), the WHERE clause in sb2 will also be updated.
+	sb1.Where(
+		sb1.Like("name", "Charmy%"),
+	)
+
+	// We can get a copy of the WhereClause.
+	// The copy is independent from the original.
+	sb3 := Select("name").From("users")
+	sb3.WhereClause = CopyWhereClause(whereClause)
+
+	// Adding more expressions to sb1 and sb2 will not affect sb3.
+	sb2.Where(
+		sb2.In("status", 1, 2, 3),
+	)
+
+	// Adding more expressions to sb3 will not affect sb1 and sb2.
+	sb3.Where(
+		sb3.GreaterEqualThan("level", 10),
+	)
+
+	sql1, args1 := sb1.Build()
+	sql2, args2 := sb2.Build()
+	sql3, args3 := sb3.Build()
+
+	fmt.Println(sql1)
+	fmt.Println(args1)
+	fmt.Println(sql2)
+	fmt.Println(args2)
+	fmt.Println(sql3)
+	fmt.Println(args3)
+
+	// Output:
+	// SELECT level FROM users WHERE name LIKE ? AND status IN (?, ?, ?)
+	// [Charmy% 1 2 3]
+	// SELECT status FROM users WHERE name LIKE ? AND status IN (?, ?, ?)
+	// [Charmy% 1 2 3]
+	// SELECT name FROM users WHERE name LIKE ? AND level >= ?
+	// [Charmy% 10]
+}
+
+func ExampleWhereClause_clearWhereClause() {
+	db := DeleteFrom("users")
+	db.Where(
+		db.GreaterThan("level", 10),
+	)
+
+	sql, args := db.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Clear WHERE clause.
+	db.WhereClause = nil
+	sql, args = db.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	db.Where(
+		db.Equal("id", 1234),
+	)
+	sql, args = db.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// DELETE FROM users WHERE level > ?
+	// [10]
+	// DELETE FROM users
+	// []
+	// DELETE FROM users WHERE id = ?
+	// [1234]
+}
+
+func ExampleWhereClause_AddWhereExpr() {
+	// WhereClause can be used as a standalone builder to build WHERE clause.
+	// It's recommended to use it with Cond.
+	whereClause := NewWhereClause()
+	cond := NewCond()
+
+	whereClause.AddWhereExpr(
+		cond.Args,
+		cond.In("name", "Charmy", "Huan"),
+		cond.LessEqualThan("level", 10),
+	)
+
+	// Set the flavor of the WhereClause to PostgreSQL.
+	whereClause.SetFlavor(PostgreSQL)
+
+	sql, args := whereClause.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Use this WhereClause in another builder.
+	sb := MySQL.NewSelectBuilder()
+	sb.Select("name", "level").From("users")
+	sb.WhereClause = whereClause
+
+	// The flavor of sb overrides the flavor of the WhereClause.
+	sql, args = sb.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// WHERE name IN ($1, $2) AND level <= $3
+	// [Charmy Huan 10]
+	// SELECT name, level FROM users WHERE name IN (?, ?) AND level <= ?
+	// [Charmy Huan 10]
+}
+
+func ExampleWhereClause_AddWhereClause() {
+	sb := Select("level").From("users")
+	sb.Where(
+		sb.Equal("id", 1234),
+	)
+
+	sql, args := sb.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	ub := Update("users")
+	ub.Set(
+		ub.Add("level", 10),
+	)
+
+	// Copy the WHERE clause of sb into ub and add more expressions.
+	ub.AddWhereClause(sb.WhereClause).Where(
+		ub.Equal("deleted", 0),
+	)
+
+	sql, args = ub.Build()
+	fmt.Println(sql)
+	fmt.Println(args)
+
+	// Output:
+	// SELECT level FROM users WHERE id = ?
+	// [1234]
+	// UPDATE users SET level = level + ? WHERE id = ? AND deleted = ?
+	// [10 1234 0]
+}


### PR DESCRIPTION
Due to the importance of the `WHERE` statement in SQL, we often need to continuously append conditions and even share some common `WHERE` conditions among different builders. Therefore, we abstract the `WHERE` statement into a `WhereClause` struct, which can be used to create reusable `WHERE` conditions.

`SelectBuilder`, `UpdateBuilder` and `DeleteBuilder` have a new anonymous field `WhereClause` now to expose necessary APIs. Read the samples in the file `whereclause_test.go` as HOW-TO documents for `WhereClause` in all kinds of scenarios.