### PR TITLE
Add ilike helper method

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ There are many methods for building conditions.
 - [Cond.In](https://pkg.go.dev/github.com/huandu/go-sqlbuilder#Cond.In): `field IN (value1, value2, ...)`.
 - [Cond.NotIn](https://pkg.go.dev/github.com/huandu/go-sqlbuilder#Cond.NotIn): `field NOT IN (value1, value2, ...)`.
 - [Cond.Like](https://pkg.go.dev/github.com/huandu/go-sqlbuilder#Cond.Like): `field LIKE value`.
+- [Cond.ILike](https://pkg.go.dev/github.com/huandu/go-sqlbuilder#Cond.ILike): `field ILIKE value`.
 - [Cond.NotLike](https://pkg.go.dev/github.com/huandu/go-sqlbuilder#Cond.NotLike): `field NOT LIKE value`.
 - [Cond.Between](https://pkg.go.dev/github.com/huandu/go-sqlbuilder#Cond.Between): `field BETWEEN lower AND upper`.
 - [Cond.NotBetween](https://pkg.go.dev/github.com/huandu/go-sqlbuilder#Cond.NotBetween): `field NOT BETWEEN lower AND upper`.

--- a/cond.go
+++ b/cond.go
@@ -170,6 +170,15 @@ func (c *Cond) Like(field string, value interface{}) string {
 	return buf.String()
 }
 
+// ILike represents "field ILIKE value".
+func (c *Cond) ILike(field string, value interface{}) string {
+	buf := newStringBuilder()
+	buf.WriteString(Escape(field))
+	buf.WriteString(" ILIKE ")
+	buf.WriteString(c.Args.Add(value))
+	return buf.String()
+}
+
 // NotLike represents "field NOT LIKE value".
 func (c *Cond) NotLike(field string, value interface{}) string {
 	buf := newStringBuilder()

--- a/cond_test.go
+++ b/cond_test.go
@@ -33,6 +33,7 @@ func TestCond(t *testing.T) {
 		"$$a IN ($0, $1, $2)":         func() string { return newTestCond().In("$a", 1, 2, 3) },
 		"$$a NOT IN ($0, $1, $2)":     func() string { return newTestCond().NotIn("$a", 1, 2, 3) },
 		"$$a LIKE $0":                 func() string { return newTestCond().Like("$a", "%Huan%") },
+		"$$a ILIKE $0":                func() string { return newTestCond().ILike("$a", "%Huan%") },
 		"$$a NOT LIKE $0":             func() string { return newTestCond().NotLike("$a", "%Huan%") },
 		"$$a IS NULL":                 func() string { return newTestCond().IsNull("$a") },
 		"$$a IS NOT NULL":             func() string { return newTestCond().IsNotNull("$a") },


### PR DESCRIPTION
## Summary

 Add `ILIKE` helper method for make it easy to filter by `ILIKE` condition
 
 So instead of writing this
 ```go
 builder.Where( "username ILIKE " + builder.Var("%"+User.Name+"%"))
```

we will use this

```go
  builder.Where(builder.ILike("username", "%"+User.Name+"%"))
```