### PR TITLE
feat: add MATCH* query syntax for doris

### DIFF
--- a/cond.go
+++ b/cond.go
@@ -320,3 +320,46 @@ func (c *Cond) Some(field, op string, value ...interface{}) string {
 func (c *Cond) Var(value interface{}) string {
 	return c.Args.Add(value)
 }
+
+func (c *Cond) MatchAll(field string, value interface{}) string {
+	buf := newStringBuilder()
+	buf.WriteString(Escape(field))
+	buf.WriteString(" MATCH_ALL ")
+	buf.WriteString(c.Args.Add(value))
+	return buf.String()
+}
+
+func (c *Cond) MatchAny(field string, value interface{}) string {
+	buf := newStringBuilder()
+	buf.WriteString(Escape(field))
+	buf.WriteString(" MATCH_ANY ")
+	buf.WriteString(c.Args.Add(value))
+	return buf.String()
+}
+
+func (c *Cond) MatchPhrase(field, slop string, value interface{}) string {
+	buf := newStringBuilder()
+	buf.WriteString(Escape(field))
+	buf.WriteString(" MATCH_PHRASE ")
+	buf.WriteString(c.Args.Add(value))
+	if slop != "" {
+		buf.WriteString(" " + slop)
+	}
+	return buf.String()
+}
+
+func (c *Cond) MatchPhrasePrefix(field string, value interface{}) string {
+	buf := newStringBuilder()
+	buf.WriteString(Escape(field))
+	buf.WriteString(" MATCH_PHRASE_PREFIX ")
+	buf.WriteString(c.Args.Add(value))
+	return buf.String()
+}
+
+func (c *Cond) MatchRegexp(field string, value interface{}) string {
+	buf := newStringBuilder()
+	buf.WriteString(Escape(field))
+	buf.WriteString(" MATCH_REGEXP ")
+	buf.WriteString(c.Args.Add(value))
+	return buf.String()
+}

--- a/cond_test.go
+++ b/cond_test.go
@@ -47,6 +47,12 @@ func TestCond(t *testing.T) {
 		"$$a < ALL ($0)":              func() string { return newTestCond().All("$a", "<", 1) },
 		"$$a > SOME ($0, $1, $2)":     func() string { return newTestCond().Some("$a", ">", 1, 2, 3) },
 		"$0":                          func() string { return newTestCond().Var(123) },
+		"$$a MATCH_ALL $0":            func() string { return newTestCond().MatchAll("$a", "1 2 3") },
+		"$$a MATCH_ANY $0":            func() string { return newTestCond().MatchAny("$a", "1 2 3") },
+		"$$a MATCH_PHRASE $0":         func() string { return newTestCond().MatchPhrase("$a", "", "1 2 3") },
+		"$$a MATCH_PHRASE $0 ~3+":     func() string { return newTestCond().MatchPhrase("$a", "~3+", "1 2 3") },
+		"$$a MATCH_PHRASE_PREFIX $0":  func() string { return newTestCond().MatchPhrasePrefix("$a", "1 2 3") },
+		"$$a MATCH_REGEXP $0":         func() string { return newTestCond().MatchRegexp("$a", "1 2 3") },
 	}
 
 	for expected, f := range cases {


### PR DESCRIPTION
This is an great repository. I want to use sql builder in doris operations. But I find there are not methods for MATCH_ALL、MATCH_ANY、MATCH_PHRASE、MATCH_PHRASE_PREFIX、MATCH_REGEXP operating. 
See doris doc:
https://doris.apache.org/docs/2.1/table-design/index/inverted-index/#accelerating-queries-with-inverted-indexes

So I add some MATCH* relative method and testing cases. Please take a view.