### PR TITLE
Automatically ref names of CTETables in DELETE and UPDATE statements

### DIFF
--- a/cte.go
+++ b/cte.go
@@ -138,12 +138,12 @@ func (cteb *CTEBuilder) TableNames() []string {
 	return tableNames
 }
 
-// tableNamesForSelect returns a list of table names which should be automatically added to FROM clause.
-// It's not public, as this feature is designed only for SelectBuilder right now.
-func (cteb *CTEBuilder) tableNamesForSelect() []string {
+// tableNamesForFrom returns a list of table names which should be automatically added to FROM clause.
+// It's not public, as this feature is designed only for SelectBuilder/UpdateBuilder/DeleteBuilder right now.
+func (cteb *CTEBuilder) tableNamesForFrom() []string {
 	cnt := 0
 
-	// It's rare that the ShouldAddToTableList() returns true.
+	// ShouldAddToTableList() unlikely returns true.
 	// Count it before allocating any memory for better performance.
 	for _, query := range cteb.queries {
 		if query.ShouldAddToTableList() {

--- a/cte_test.go
+++ b/cte_test.go
@@ -82,6 +82,43 @@ func ExampleCTEBuilder() {
 	// [users valid_users]
 }
 
+func ExampleCTEBuilder_update() {
+	builder := With(
+		CTETable("users", "user_id").As(
+			Select("user_id").From("vip_users"),
+		),
+	).Update("orders").Set(
+		"orders.transport_fee = 0",
+	).Where(
+		"users.user_id = orders.user_id",
+	)
+
+	sqlForMySQL, _ := builder.BuildWithFlavor(MySQL)
+	sqlForPostgreSQL, _ := builder.BuildWithFlavor(PostgreSQL)
+
+	fmt.Println(sqlForMySQL)
+	fmt.Println(sqlForPostgreSQL)
+
+	// Output:
+	// WITH users (user_id) AS (SELECT user_id FROM vip_users) UPDATE orders, users SET orders.transport_fee = 0 WHERE users.user_id = orders.user_id
+	// WITH users (user_id) AS (SELECT user_id FROM vip_users) UPDATE orders FROM users SET orders.transport_fee = 0 WHERE users.user_id = orders.user_id
+}
+
+func ExampleCTEBuilder_delete() {
+	sql := With(
+		CTETable("users", "user_id").As(
+			Select("user_id").From("cheaters"),
+		),
+	).DeleteFrom("awards").Where(
+		"users.user_id = awards.user_id",
+	).String()
+
+	fmt.Println(sql)
+
+	// Output:
+	// WITH users (user_id) AS (SELECT user_id FROM cheaters) DELETE FROM awards, users WHERE users.user_id = awards.user_id
+}
+
 func TestCTEBuilder(t *testing.T) {
 	a := assert.New(t)
 	cteb := newCTEBuilder()

--- a/select.go
+++ b/select.go
@@ -96,12 +96,12 @@ func Select(col ...string) *SelectBuilder {
 	return DefaultFlavor.NewSelectBuilder().Select(col...)
 }
 
-// TableNames returns all table names in a SELECT.
+// TableNames returns all table names in this SELECT statement.
 func (sb *SelectBuilder) TableNames() []string {
 	var additionalTableNames []string
 
 	if sb.cteBuilder != nil {
-		additionalTableNames = sb.cteBuilder.tableNamesForSelect()
+		additionalTableNames = sb.cteBuilder.tableNamesForFrom()
 	}
 
 	var tableNames []string


### PR DESCRIPTION
Per #176, The names of CTE tables created by `CTETable` can be automatically added to `FROM` clause in `DELETE` and `UPDATE` statement. The `UPDATE` statement in MySQL is an exception as MySQL uses different syntax.

See `ExampleCTEBuilder_update` and `ExampleCTEBuilder_delete` in `./cte_test.go` for more details.