### PR TITLE
Avoid stack overflow when Cond is misused

### DIFF
--- a/args_test.go
+++ b/args_test.go
@@ -23,7 +23,7 @@ func TestArgs(t *testing.T) {
 	cases := map[string][]interface{}{
 		"abc ? def\n[123]":                   {"abc $? def", 123},
 		"abc ? def\n[456]":                   {"abc $0 def", 456},
-		"abc  def\n[]":                       {"abc $1 def", 123},
+		"abc /* INVALID ARG $1 */ def\n[]":   {"abc $1 def", 123},
 		"abc  def \n[]":                      {"abc ${unknown} def ", 123},
 		"abc $ def\n[]":                      {"abc $$ def", 123},
 		"abcdef$\n[]":                        {"abcdef$", 123},

--- a/cond.go
+++ b/cond.go
@@ -11,6 +11,8 @@ const (
 	opNOT  = "NOT "
 )
 
+const minIndexBase = 256
+
 // Cond provides several helper methods to build conditions.
 type Cond struct {
 	Args *Args
@@ -19,7 +21,17 @@ type Cond struct {
 // NewCond returns a new Cond.
 func NewCond() *Cond {
 	return &Cond{
-		Args: &Args{},
+		Args: &Args{
+			// Based on the discussion in #174, users may call this method to create
+			// `Cond` for building various conditions, which is a misuse, but we
+			// cannot completely prevent this error. To facilitate users in
+			// identifying the issue when they make mistakes and to avoid
+			// unexpected stackoverflows, the base index for `Args` is
+			// deliberately set to a larger non-zero value here. This can
+			// significantly reduce the likelihood of issues and allows for
+			// timely error notification to users.
+			indexBase: minIndexBase,
+		},
 	}
 }
 

--- a/cond_test.go
+++ b/cond_test.go
@@ -230,3 +230,16 @@ func TestCondExpr(t *testing.T) {
 		a.Equal(actual, expected)
 	}
 }
+
+func TestCondMisuse(t *testing.T) {
+	a := assert.New(t)
+
+	cond := NewCond()
+	sb := Select("*").
+		From("t1").
+		Where(cond.Equal("a", 123))
+	sql, args := sb.Build()
+
+	a.Equal(sql, "SELECT * FROM t1 WHERE /* INVALID ARG $256 */")
+	a.Equal(args, nil)
+}


### PR DESCRIPTION
Per #178, if one misuses `Cond` in a WHERE clause, make the error visible and avoid stack overflow exception.