### PR TITLE
fix: prevent syntax error on empty value set for IN/NOT IN

### DIFF
--- a/cond.go
+++ b/cond.go
@@ -190,6 +190,11 @@ func (c *Cond) In(field string, values ...interface{}) string {
 		return ""
 	}
 
+	if len(values) == 0 {
+		// An empty list of values for an "in", means we want to filter out all results.
+		return c.Not("2 = 2")
+	}
+
 	return c.Var(condBuilder{
 		Builder: func(ctx *argsCompileContext) {
 			ctx.WriteString(field)
@@ -202,7 +207,8 @@ func (c *Cond) In(field string, values ...interface{}) string {
 
 // NotIn is used to construct the expression "field NOT IN (value...)".
 func (c *Cond) NotIn(field string, values ...interface{}) string {
-	if len(field) == 0 {
+	if len(field) == 0 || len(values) == 0 {
+		// An empty list of values for a "not in", means we don't want this condition to filter.
 		return ""
 	}
 

--- a/cond_test.go
+++ b/cond_test.go
@@ -55,6 +55,8 @@ func TestCond(t *testing.T) {
 		"$a IS DISTINCT FROM $1":     func(cond *Cond) string { return cond.IsDistinctFrom("$a", 1) },
 		"$a IS NOT DISTINCT FROM $1": func(cond *Cond) string { return cond.IsNotDistinctFrom("$a", 1) },
 		"$1":                         func(cond *Cond) string { return cond.Var(123) },
+		"NOT 2 = 2":                  func(cond *Cond) string { return cond.In("field") },
+		"":                           func(cond *Cond) string { return cond.NotIn("field") },
 	}
 
 	for expected, f := range cases {


### PR DESCRIPTION
Currently, when we (accidentally) pass an empty slice of values to an `IN(...)` or `NOT IN(...)` condition, the query serializes okay, but errors on execution, because it yields something along the lines of:

```sql
SELECT * FROM users WHERE id IN ()`
```

This tweak aims to fix that. The `NOT 2=2` is a bit sub optimal, but it's because the rendered queries are used as keys in the test cases, and there was already a `NOT 1=1`.

Open to feedback. Thanks!