### PR TITLE
Fix #186: use args in LIMIT and/or OFFSET expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ sql := sqlbuilder.CreateTable("users").
     SQL(
         sqlbuilder.Select("columns[0] id", "columns[1] name", "columns[2] year").
             From("`all-users.csv`").
-            Limit(100).
             String(),
     ).
     String()
@@ -104,7 +103,7 @@ sql := sqlbuilder.CreateTable("users").
 fmt.Println(sql)
 
 // Output:
-// CREATE TABLE users PARTITION BY (year) AS SELECT columns[0] id, columns[1] name, columns[2] year FROM `all-users.csv` LIMIT 100
+// CREATE TABLE users PARTITION BY (year) AS SELECT columns[0] id, columns[1] name, columns[2] year FROM `all-users.csv`
 ```
 
 Below are several utility methods designed to address special cases.

--- a/delete_test.go
+++ b/delete_test.go
@@ -21,7 +21,7 @@ func ExampleDeleteFrom() {
 	fmt.Println(sql)
 
 	// Output:
-	// DELETE FROM demo.user WHERE status = 1 LIMIT 10
+	// DELETE FROM demo.user WHERE status = 1 LIMIT ?
 }
 
 func ExampleDeleteBuilder() {
@@ -65,8 +65,8 @@ func ExampleDeleteBuilder_SQL() {
 	fmt.Println(args)
 
 	// Output:
-	// /* before */ DELETE FROM demo.user PARTITION (p0) WHERE id > ? /* after where */ ORDER BY id /* after order by */ LIMIT 10 /* after limit */
-	// [1234]
+	// /* before */ DELETE FROM demo.user PARTITION (p0) WHERE id > ? /* after where */ ORDER BY id /* after order by */ LIMIT ? /* after limit */
+	// [1234 10]
 }
 
 func ExampleDeleteBuilder_With() {

--- a/struct_test.go
+++ b/struct_test.go
@@ -1036,6 +1036,6 @@ func ExampleFieldMapperFunc() {
 	fmt.Println(sql1 == sql2)
 
 	// Output:
-	// SELECT orders.id, orders.user_id, orders.product_name, orders.status, orders.user_addr_line1, orders.user_addr_line2, orders.created_at FROM orders LIMIT 10
+	// SELECT orders.id, orders.user_id, orders.product_name, orders.status, orders.user_addr_line1, orders.user_addr_line2, orders.created_at FROM orders LIMIT ?
 	// true
 }

--- a/union_test.go
+++ b/union_test.go
@@ -54,8 +54,8 @@ func ExampleUnionAll() {
 	fmt.Println(args)
 
 	// Output:
-	// (SELECT id, name, created_at FROM demo.user WHERE id > ?) UNION ALL (TABLE demo.user_profile) ORDER BY created_at ASC LIMIT 100 OFFSET 5
-	// [1234]
+	// (SELECT id, name, created_at FROM demo.user WHERE id > ?) UNION ALL (TABLE demo.user_profile) ORDER BY created_at ASC LIMIT ? OFFSET ?
+	// [1234 100 5]
 }
 
 func ExampleUnionBuilder_SQL() {
@@ -80,7 +80,7 @@ func ExampleUnionBuilder_SQL() {
 	fmt.Println(sql)
 
 	// Output:
-	// /* before */ (SELECT id, name, created_at FROM demo.user) UNION (SELECT id, avatar FROM demo.user_profile) /* after union */ ORDER BY created_at DESC /* after order by */ LIMIT 100 OFFSET 5 /* after limit */
+	// /* before */ (SELECT id, name, created_at FROM demo.user) UNION (SELECT id, avatar FROM demo.user_profile) /* after union */ ORDER BY created_at DESC /* after order by */ LIMIT ? OFFSET ? /* after limit */
 }
 
 func TestUnionForSQLite(t *testing.T) {

--- a/update_test.go
+++ b/update_test.go
@@ -114,7 +114,7 @@ func ExampleUpdateBuilder_SQL() {
 	fmt.Println(sql)
 
 	// Output:
-	// /* before */ UPDATE demo.user /* after update */ SET type = ? /* after set */ ORDER BY id DESC /* after order by */ LIMIT 10 /* after limit */
+	// /* before */ UPDATE demo.user /* after update */ SET type = ? /* after set */ ORDER BY id DESC /* after order by */ LIMIT ? /* after limit */
 }
 
 func ExampleUpdateBuilder_NumAssignment() {


### PR DESCRIPTION
Per #186, this feature can be helpful to generate query planner friendly SQL statements.