### PR TITLE
Fix the order of LIMIT and OFFSET clauses when using the Presto flavor (issue #195)

### DIFF
--- a/select.go
+++ b/select.go
@@ -468,6 +468,10 @@ func (sb *SelectBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{
 			buf.WriteString(sb.offsetVar)
 		}
 	case Presto:
+		// There might be a hidden constraint in Presto requiring offset to be set before limit.
+		// The select statement documentation (https://prestodb.io/docs/current/sql/select.html)
+		// puts offset before limit, and Trino, which is based on Presto, seems
+		// to require this specific order.
 		if len(sb.offsetVar) > 0 {
 			buf.WriteLeadingString("OFFSET ")
 			buf.WriteString(sb.offsetVar)

--- a/select.go
+++ b/select.go
@@ -457,7 +457,7 @@ func (sb *SelectBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{
 			buf.WriteLeadingString("LIMIT ")
 			buf.WriteString(sb.limitVar)
 		}
-	case PostgreSQL, Presto:
+	case PostgreSQL:
 		if len(sb.limitVar) > 0 {
 			buf.WriteLeadingString("LIMIT ")
 			buf.WriteString(sb.limitVar)
@@ -466,6 +466,16 @@ func (sb *SelectBuilder) BuildWithFlavor(flavor Flavor, initialArg ...interface{
 		if len(sb.offsetVar) > 0 {
 			buf.WriteLeadingString("OFFSET ")
 			buf.WriteString(sb.offsetVar)
+		}
+	case Presto:
+		if len(sb.offsetVar) > 0 {
+			buf.WriteLeadingString("OFFSET ")
+			buf.WriteString(sb.offsetVar)
+		}
+
+		if len(sb.limitVar) > 0 {
+			buf.WriteLeadingString("LIMIT ")
+			buf.WriteString(sb.limitVar)
 		}
 
 	case SQLServer:

--- a/select_test.go
+++ b/select_test.go
@@ -229,9 +229,9 @@ func ExampleSelectBuilder_limit_offset() {
 	// Presto
 	// #1: SELECT * FROM user
 	// #2: SELECT * FROM user OFFSET ?
-	// #3: SELECT * FROM user LIMIT ? OFFSET ?
+	// #3: SELECT * FROM user OFFSET ? LIMIT ?
 	// #4: SELECT * FROM user LIMIT ?
-	// #5: SELECT * FROM user ORDER BY id LIMIT ? OFFSET ?
+	// #5: SELECT * FROM user ORDER BY id OFFSET ? LIMIT ?
 	//
 	// Oracle
 	// #1: SELECT * FROM user


### PR DESCRIPTION
Fix for #195:

Queries that have both a limit and an offset build a query with a limit clause *before* the offset clause.

```go
fmt.Println(Select("*").From("table").Offset(5).Limit(10))
// SELECT * FROM table LIMIT 10 OFFSET 5
```

This seems to generate syntax errors in Trino. [Presto documentation specifies OFFSET before LIMIT](https://prestodb.io/docs/current/sql/select.html#limit-clause) in the SELECT statement documentation too, but is not very explicit about the reverse not being supported.

If the OFFSET and LIMIT clauses are swapped, the query succeeds.

Expected:

```go
fmt.Println(Select("*").From("table").Offset(5).Limit(10))
// SELECT * FROM table OFFSET 5 LIMIT 10
```