### PR TITLE
[bugfix] Nil pointer deref

### DIFF
--- a/select_test.go
+++ b/select_test.go
@@ -420,4 +420,5 @@ func ExampleSelectBuilder_LateralAs() {
 
 func TestNilPointerWhere(t *testing.T) {
 	NewSelectBuilder().SQL("$0").Build()
+	NewSelectBuilder().SQL("$0").BuildWithFlavor(DefaultFlavor)
 }

--- a/select_test.go
+++ b/select_test.go
@@ -417,3 +417,7 @@ func ExampleSelectBuilder_LateralAs() {
 	// Output:
 	// SELECT salesperson.name, max_sale.amount, max_sale.customer_name FROM salesperson, LATERAL (SELECT amount, customer_name FROM all_sales WHERE all_sales.salesperson_id = salesperson.id ORDER BY amount DESC LIMIT ?) AS max_sale
 }
+
+func TestNilPointerWhere(t *testing.T) {
+	NewSelectBuilder().SQL("$0").Build()
+}

--- a/whereclause.go
+++ b/whereclause.go
@@ -60,7 +60,7 @@ var _ Builder = new(whereClauseProxy)
 
 // BuildWithFlavor builds a WHERE clause with the specified flavor and initial arguments.
 func (wc *WhereClause) BuildWithFlavor(flavor Flavor, initialArg ...interface{}) (sql string, args []interface{}) {
-	if len(wc.clauses) == 0 {
+	if wc == nil || len(wc.clauses) == 0 {
 		return "", nil
 	}
 
@@ -128,6 +128,9 @@ func (wc *WhereClause) AddWhereExpr(args *Args, andExpr ...string) *WhereClause 
 
 // AddWhereClause adds all clauses in the whereClause to the wc.
 func (wc *WhereClause) AddWhereClause(whereClause *WhereClause) *WhereClause {
+	if wc == nil {
+		return nil
+	}
 	if whereClause == nil {
 		return wc
 	}


### PR DESCRIPTION
Associated issue here: #205.

This PR creates a reproducer and a bug fix for a nil dereference crash:
```
--- FAIL: TestRegressionNilDeref (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x61ff82]
```

I believe the nil check need to be done in multiple other places and thus, maybe a more generic solution is warranted, but for the time being, that might be already an improvement :)
