### PR TITLE
Support clone (deep copy) in all builders

### DIFF
--- a/createtable.go
+++ b/createtable.go
@@ -5,6 +5,8 @@ package sqlbuilder
 
 import (
 	"strings"
+
+	"github.com/huandu/go-clone"
 )
 
 const (
@@ -27,6 +29,12 @@ func newCreateTableBuilder() *CreateTableBuilder {
 		injection: newInjection(),
 		marker:    createTableMarkerInit,
 	}
+}
+
+// Clone returns a deep copy of CreateTableBuilder.
+// It's useful when you want to create a base builder and clone it to build similar queries.
+func (ctb *CreateTableBuilder) Clone() *CreateTableBuilder {
+	return clone.Clone(ctb).(*CreateTableBuilder)
 }
 
 // CreateTableBuilder is a builder to build CREATE TABLE.

--- a/createtable_test.go
+++ b/createtable_test.go
@@ -102,3 +102,22 @@ func TestCreateTableGetFlavor(t *testing.T) {
 	flavor = ctbClick.Flavor()
 	a.Equal(ClickHouse, flavor)
 }
+
+func TestCreateTableClone(t *testing.T) {
+	a := assert.New(t)
+	ctb := CreateTable("demo.user").IfNotExists().
+		Define("id", "BIGINT(20)", "NOT NULL", "AUTO_INCREMENT", "PRIMARY KEY", `COMMENT "user id"`).
+		Option("DEFAULT CHARACTER SET", "utf8mb4")
+
+	ctb2 := ctb.Clone()
+	ctb2.Define("name", "VARCHAR(255)", "NOT NULL", `COMMENT "user name"`)
+
+	sql1, args1 := ctb.Build()
+	sql2, args2 := ctb2.Build()
+
+	a.Equal("CREATE TABLE IF NOT EXISTS demo.user (id BIGINT(20) NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT \"user id\") DEFAULT CHARACTER SET utf8mb4", sql1)
+	a.Equal(0, len(args1))
+
+	a.Equal("CREATE TABLE IF NOT EXISTS demo.user (id BIGINT(20) NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT \"user id\", name VARCHAR(255) NOT NULL COMMENT \"user name\") DEFAULT CHARACTER SET utf8mb4", sql2)
+	a.Equal(0, len(args2))
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/huandu/go-assert v1.1.6
+	github.com/huandu/go-clone v1.7.3
 	github.com/huandu/xstrings v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/huandu/go-assert v1.1.6 h1:oaAfYxq9KNDi9qswn/6aE0EydfxSa+tWZC1KabNitYs=
 github.com/huandu/go-assert v1.1.6/go.mod h1:JuIfbmYG9ykwvuxoJ3V8TB5QP+3+ajIA54Y44TmkMxs=
+github.com/huandu/go-clone v1.7.3 h1:rtQODA+ABThEn6J5LBTppJfKmZy/FwfpMUWa8d01TTQ=
+github.com/huandu/go-clone v1.7.3/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/insert.go
+++ b/insert.go
@@ -6,6 +6,8 @@ package sqlbuilder
 import (
 	"fmt"
 	"strings"
+
+	"github.com/huandu/go-clone"
 )
 
 const (
@@ -29,6 +31,12 @@ func newInsertBuilder() *InsertBuilder {
 		args:      args,
 		injection: newInjection(),
 	}
+}
+
+// Clone returns a deep copy of InsertBuilder.
+// It's useful when you want to create a base builder and clone it to build similar queries.
+func (ib *InsertBuilder) Clone() *InsertBuilder {
+	return clone.Clone(ib).(*InsertBuilder)
 }
 
 // InsertBuilder is a builder to build INSERT.

--- a/insert_test.go
+++ b/insert_test.go
@@ -317,3 +317,21 @@ func TestIssue200(t *testing.T) {
 	query, _ := ib.Build()
 	a.Equal(query, "INSERT INTO table (data) SELECT id, data FROM table WHERE id = $1 ON CONFLICT DO NOTHING")
 }
+
+func TestInsertBuilderClone(t *testing.T) {
+	a := assert.New(t)
+
+	ib := InsertInto("demo.user").Cols("id", "name")
+	ib.Values(1, "A")
+
+	clone := ib.Clone()
+
+	s1, args1 := ib.Build()
+	s2, args2 := clone.Build()
+	a.Equal(s1, s2)
+	a.Equal(args1, args2)
+
+	// mutate clone and verify original unchanged
+	clone.Values(2, "B")
+	a.NotEqual(ib.String(), clone.String())
+}

--- a/struct_test.go
+++ b/struct_test.go
@@ -328,13 +328,14 @@ func (rows testRows) Close() error {
 }
 
 func (rows testRows) Scan(dest ...interface{}) error {
-	if rows == 0 {
+	switch rows {
+	case 0:
 		fmt.Sscan("1234 huandu 1", dest...)
-	} else if rows == 1 {
+	case 1:
 		fmt.Sscan("1234 34 huandu 1456725903636000000", dest...)
-	} else if rows == 2 {
+	case 2:
 		fmt.Sscan("1 1456725903636000000", dest...)
-	} else {
+	default:
 		panic("invalid rows")
 	}
 

--- a/union_test.go
+++ b/union_test.go
@@ -245,3 +245,21 @@ func ExampleUnionBuilder_limit_offset() {
 	// #4: (SELECT * FROM user1) UNION (SELECT * FROM user2) LIMIT 1
 	// #5: (SELECT * FROM user1) UNION (SELECT * FROM user2) ORDER BY id LIMIT 1 OFFSET 1
 }
+
+func TestUnionBuilderClone(t *testing.T) {
+	a := assert.New(t)
+	sb1 := Select("id", "name").From("users").Where("active = 1")
+	sb2 := Select("id", "nick").From("profiles").Where("status IN (1,2)")
+
+	ub := UnionAll(sb1, sb2).OrderBy("id").Desc().Limit(5).Offset(1)
+	clone := ub.Clone()
+
+	s1, args1 := ub.Build()
+	s2, args2 := clone.Build()
+	a.Equal(s1, s2)
+	a.Equal(args1, args2)
+
+	// Change clone and ensure original unchanged
+	clone.Asc().Limit(10)
+	a.NotEqual(ub.String(), clone.String())
+}

--- a/update.go
+++ b/update.go
@@ -5,6 +5,9 @@ package sqlbuilder
 
 import (
 	"fmt"
+	"reflect"
+
+	"github.com/huandu/go-clone"
 )
 
 const (
@@ -36,6 +39,24 @@ func newUpdateBuilder() *UpdateBuilder {
 		args:      args,
 		injection: newInjection(),
 	}
+}
+
+// Clone returns a deep copy of UpdateBuilder.
+// It's useful when you want to create a base builder and clone it to build similar queries.
+func (ub *UpdateBuilder) Clone() *UpdateBuilder {
+	return clone.Clone(ub).(*UpdateBuilder)
+}
+
+func init() {
+	t := reflect.TypeOf(UpdateBuilder{})
+	clone.SetCustomFunc(t, func(allocator *clone.Allocator, old, new reflect.Value) {
+		cloned := allocator.CloneSlowly(old)
+		new.Set(cloned)
+
+		ub := cloned.Addr().Interface().(*UpdateBuilder)
+		ub.args.Replace(ub.whereClauseExpr, ub.whereClauseProxy)
+		ub.args.Replace(ub.cteBuilderVar, ub.cteBuilder)
+	})
 }
 
 // UpdateBuilder is a builder to build UPDATE.


### PR DESCRIPTION
Per discussion in #211, this PR adds `Clone` methods for all builders to make it possible to use any builder as a template.